### PR TITLE
Provide better extensibility of most aspects of EMFJson

### DIFF
--- a/src/main/java/org/emfjson/jackson/databind/deser/EObjectDeserializer.java
+++ b/src/main/java/org/emfjson/jackson/databind/deser/EObjectDeserializer.java
@@ -37,8 +37,8 @@ import static org.emfjson.jackson.databind.EMFContext.getResource;
 
 public class EObjectDeserializer extends JsonDeserializer<EObject> {
 
-	private final EObjectPropertyMap.Builder builder;
-	private final Class<?> currentType;
+	protected final EObjectPropertyMap.Builder builder;
+	protected final Class<?> currentType;
 
 	public EObjectDeserializer(EObjectPropertyMap.Builder builder, Class<?> currentType) {
 		this.builder = builder;
@@ -78,7 +78,7 @@ public class EObjectDeserializer extends JsonDeserializer<EObject> {
 			} else if (property != null && current != null) {
 				property.deserializeAndSet(jp, current, ctxt, resource);
 			} else if (property == null && current != null) {
-				handleUnknownProperty(jp, resource, ctxt);
+				handleUnknownProperty(jp, current, ctxt, resource);
 			} else {
 				if (buffer == null) {
 					buffer = new TokenBuffer(jp);
@@ -114,14 +114,14 @@ public class EObjectDeserializer extends JsonDeserializer<EObject> {
 			if (property != null) {
 				property.deserializeAndSet(jp, intoValue, ctxt, resource);
 			} else {
-				handleUnknownProperty(jp, resource, ctxt);
+				handleUnknownProperty(jp, intoValue, ctxt, resource);
 			}
 		}
 
 		return intoValue;
 	}
 
-	private EObject postDeserialize(TokenBuffer buffer, EObject object, EClass defaultType, DeserializationContext ctxt) throws IOException {
+	protected EObject postDeserialize(TokenBuffer buffer, EObject object, EClass defaultType, DeserializationContext ctxt) throws IOException {
 		if (object == null && defaultType == null) {
 			return null;
 		}
@@ -158,7 +158,7 @@ public class EObjectDeserializer extends JsonDeserializer<EObject> {
 			if (property != null) {
 				property.deserializeAndSet(jp, object, ctxt, resource);
 			} else {
-				handleUnknownProperty(jp, resource, ctxt);
+				handleUnknownProperty(jp, object, ctxt, resource);
 			}
 
 			nextToken = jp.nextToken();
@@ -169,7 +169,7 @@ public class EObjectDeserializer extends JsonDeserializer<EObject> {
 		return object;
 	}
 
-	private void handleUnknownProperty(JsonParser jp, Resource resource, DeserializationContext ctxt) throws IOException {
+	protected void handleUnknownProperty(JsonParser jp, EObject current, DeserializationContext ctxt, Resource resource) throws IOException {
 		if (resource != null && ctxt.getConfig().hasDeserializationFeatures(FAIL_ON_UNKNOWN_PROPERTIES.getMask())) {
 			resource.getErrors().add(new JSONException("Unknown feature " + jp.getCurrentName(), jp.getCurrentLocation()));
 		}
@@ -189,7 +189,7 @@ public class EObjectDeserializer extends JsonDeserializer<EObject> {
 		return EObject.class;
 	}
 
-	private EClass getDefaultType(DeserializationContext ctxt) {
+	protected EClass getDefaultType(DeserializationContext ctxt) {
 		EClass type = null;
 
 		EObject parent = EMFContext.getParent(ctxt);

--- a/src/main/java/org/emfjson/jackson/databind/deser/EcoreReferenceDeserializer.java
+++ b/src/main/java/org/emfjson/jackson/databind/deser/EcoreReferenceDeserializer.java
@@ -25,8 +25,8 @@ import java.io.IOException;
 
 public class EcoreReferenceDeserializer extends JsonDeserializer<ReferenceEntry> {
 
-	private final EcoreReferenceInfo info;
-	private final EcoreTypeInfo typeInfo;
+	protected final EcoreReferenceInfo info;
+	protected final EcoreTypeInfo typeInfo;
 
 	public EcoreReferenceDeserializer(EcoreReferenceInfo info, EcoreTypeInfo typeInfo) {
 		this.typeInfo = typeInfo;

--- a/src/main/java/org/emfjson/jackson/databind/deser/ReferenceEntry.java
+++ b/src/main/java/org/emfjson/jackson/databind/deser/ReferenceEntry.java
@@ -30,10 +30,10 @@ public interface ReferenceEntry {
 
 	class Base implements ReferenceEntry {
 
-		private final EObject owner;
-		private final EReference reference;
-		private final String id;
-		private final String type;
+		protected final EObject owner;
+		protected final EReference reference;
+		protected final String id;
+		protected final String type;
 
 		public Base(EObject owner, EReference reference, String id) {
 			this(owner, reference, id, null);
@@ -82,7 +82,7 @@ public interface ReferenceEntry {
 			}
 		}
 
-		private EObject createProxy(ResourceSet resourceSet, URI uri) {
+		protected EObject createProxy(ResourceSet resourceSet, URI uri) {
 			EClass eClass;
 			try {
 				eClass = (EClass) resourceSet.getEObject(URI.createURI(type), true);

--- a/src/main/java/org/emfjson/jackson/databind/property/EObjectFeatureProperty.java
+++ b/src/main/java/org/emfjson/jackson/databind/property/EObjectFeatureProperty.java
@@ -59,37 +59,37 @@ public class EObjectFeatureProperty extends EObjectProperty {
 			return;
 		}
 
-		switch (FeatureKind.get(feature)) {
+		switch (FeatureKind.get(getFeature())) {
 			case MAP:
 			case MANY_CONTAINMENT:
 			case SINGLE_CONTAINMENT: {
-				EMFContext.setFeature(ctxt, feature);
+				EMFContext.setFeature(ctxt, getFeature());
 				EMFContext.setParent(ctxt, current);
 			}
 			case SINGLE_ATTRIBUTE:
 			case MANY_ATTRIBUTE: {
-				if (feature.getEType() instanceof EDataType) {
-					EMFContext.setDataType(ctxt, feature.getEType());
+				if (getFeature().getEType() instanceof EDataType) {
+					EMFContext.setDataType(ctxt, getFeature().getEType());
 				}
 
-				if (feature.isMany()) {
-					deserializer.deserialize(jp, ctxt, current.eGet(feature));
+				if (getFeature().isMany()) {
+					deserializer.deserialize(jp, ctxt, current.eGet(getFeature()));
 				} else {
 					Object value = deserializer.deserialize(jp, ctxt);
 
 					if (value != null) {
-						current.eSet(feature, value);
+						current.eSet(getFeature(), value);
 					}
 				}
 			}
 			break;
 			case MANY_REFERENCE:
 			case SINGLE_REFERENCE: {
-				EMFContext.setFeature(ctxt, feature);
+				EMFContext.setFeature(ctxt, getFeature());
 				EMFContext.setParent(ctxt, current);
 
 				ReferenceEntries entries = EMFContext.getEntries(ctxt);
-				if (feature.isMany()) {
+				if (getFeature().isMany()) {
 					deserializer.deserialize(jp, ctxt, entries.entries());
 				} else {
 					Object value = deserializer.deserialize(jp, ctxt);
@@ -109,10 +109,10 @@ public class EObjectFeatureProperty extends EObjectProperty {
 		}
 
 		EMFContext.setParent(provider, bean);
-		EMFContext.setFeature(provider, feature);
+		EMFContext.setFeature(provider, getFeature());
 
-		if (bean.eIsSet(feature)) {
-			Object value = bean.eGet(feature, false);
+		if (bean.eIsSet(getFeature())) {
+			Object value = bean.eGet(getFeature(), false);
 
 			jg.writeFieldName(getFieldName());
 
@@ -125,7 +125,7 @@ public class EObjectFeatureProperty extends EObjectProperty {
 				serializer.serialize(value, jg, provider);
 			}
 		} else if (defaultValues) {
-			Object value = feature.getDefaultValue();
+			Object value = getFeature().getDefaultValue();
 
 			if (value != null) {
 				jg.writeFieldName(getFieldName());
@@ -137,5 +137,9 @@ public class EObjectFeatureProperty extends EObjectProperty {
 	@Override
 	public EObject deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
 		return null;
+	}
+
+	public EStructuralFeature getFeature() {
+		return feature;
 	}
 }

--- a/src/main/java/org/emfjson/jackson/databind/property/EObjectIdentityProperty.java
+++ b/src/main/java/org/emfjson/jackson/databind/property/EObjectIdentityProperty.java
@@ -39,7 +39,7 @@ public class EObjectIdentityProperty extends EObjectProperty {
 	}
 
 	public void serialize(EObject bean, JsonGenerator jg, SerializerProvider provider) throws IOException {
-		jg.writeObjectField(getFieldName(), valueWriter.writeValue(bean, provider));
+		jg.writeObjectField(getFieldName(), valueWriter.writeValue(bean, bean, provider));
 	}
 
 	@Override
@@ -69,7 +69,7 @@ public class EObjectIdentityProperty extends EObjectProperty {
 		}
 
 		if (value != null) {
-			String id = valueReader.readValue(value, ctxt);
+			String id = valueReader.readValue(current, value, ctxt);
 			if (resource instanceof JsonResource && id != null) {
 				((JsonResource) resource).setID(current, id);
 			}

--- a/src/main/java/org/emfjson/jackson/databind/property/EObjectTypeProperty.java
+++ b/src/main/java/org/emfjson/jackson/databind/property/EObjectTypeProperty.java
@@ -59,7 +59,7 @@ public class EObjectTypeProperty extends EObjectProperty {
 		EReference containment = bean.eContainmentFeature();
 
 		if (isRoot(bean) || shouldSaveType(objectType, containment.getEReferenceType(), containment)) {
-			String value = valueWriter.writeValue(bean.eClass(), provider);
+			String value = valueWriter.writeValue(bean, bean.eClass(), provider);
 
 			jg.writeFieldName(getFieldName());
 			serializer.serialize(value, jg, provider);

--- a/src/main/java/org/emfjson/jackson/databind/ser/EObjectSerializer.java
+++ b/src/main/java/org/emfjson/jackson/databind/ser/EObjectSerializer.java
@@ -25,8 +25,8 @@ import static org.emfjson.jackson.databind.EMFContext.getParent;
 
 public class EObjectSerializer extends JsonSerializer<EObject> {
 
-	private final JsonSerializer<EObject> refSerializer;
-	private final EObjectPropertyMap.Builder builder;
+	protected final JsonSerializer<EObject> refSerializer;
+	protected final EObjectPropertyMap.Builder builder;
 
 	public EObjectSerializer(EObjectPropertyMap.Builder builder, JsonSerializer<EObject> serializer) {
 		this.builder = builder;

--- a/src/main/java/org/emfjson/jackson/databind/ser/EcoreReferenceSerializer.java
+++ b/src/main/java/org/emfjson/jackson/databind/ser/EcoreReferenceSerializer.java
@@ -28,9 +28,9 @@ import java.io.IOException;
 
 public class EcoreReferenceSerializer extends JsonSerializer<EObject> {
 
-	private final EcoreReferenceInfo info;
-	private final EcoreTypeInfo typeInfo;
-	private final URIHandler handler;
+	protected final EcoreReferenceInfo info;
+	protected final EcoreTypeInfo typeInfo;
+	protected final URIHandler handler;
 
 	public EcoreReferenceSerializer(EcoreReferenceInfo info, EcoreTypeInfo typeInfo) {
 		this.info = info;
@@ -44,7 +44,7 @@ public class EcoreReferenceSerializer extends JsonSerializer<EObject> {
 		final String href = getHRef(serializers, parent, value);
 
 		jg.writeStartObject();
-		jg.writeStringField(typeInfo.getProperty(), typeInfo.getValueWriter().writeValue(value.eClass(), serializers));
+		jg.writeStringField(typeInfo.getProperty(), typeInfo.getValueWriter().writeValue(value, value.eClass(), serializers));
 		if (href == null) {
 			jg.writeNullField(info.getProperty());
 		} else {
@@ -67,7 +67,7 @@ public class EcoreReferenceSerializer extends JsonSerializer<EObject> {
 		return sourceResource == null || sourceResource != EMFContext.getResource(ctxt, target);
 	}
 
-	private String getHRef(SerializerProvider ctxt, EObject parent, EObject value) {
+	protected String getHRef(SerializerProvider ctxt, EObject parent, EObject value) {
 		if (isExternal(ctxt, parent, value)) {
 
 			URI targetURI = EMFContext.getURI(ctxt, value);

--- a/src/main/java/org/emfjson/jackson/module/EMFModule.java
+++ b/src/main/java/org/emfjson/jackson/module/EMFModule.java
@@ -23,10 +23,13 @@ import org.emfjson.jackson.annotations.EcoreIdentityInfo;
 import org.emfjson.jackson.annotations.EcoreReferenceInfo;
 import org.emfjson.jackson.annotations.EcoreTypeInfo;
 import org.emfjson.jackson.databind.deser.EMFDeserializers;
+import org.emfjson.jackson.databind.deser.EObjectDeserializer;
 import org.emfjson.jackson.databind.deser.EcoreReferenceDeserializer;
 import org.emfjson.jackson.databind.deser.ReferenceEntry;
 import org.emfjson.jackson.databind.ser.EMFSerializers;
+import org.emfjson.jackson.databind.ser.EObjectSerializer;
 import org.emfjson.jackson.databind.ser.EcoreReferenceSerializer;
+import org.emfjson.jackson.databind.ser.EnumeratorSerializer;
 import org.emfjson.jackson.handlers.BaseURIHandler;
 import org.emfjson.jackson.handlers.URIHandler;
 
@@ -47,7 +50,11 @@ public class EMFModule extends SimpleModule {
 	private EcoreIdentityInfo identityInfo;
 
 	private JsonSerializer<EObject> referenceSerializer;
+	private JsonSerializer<?> enumeratorSerializer;
 	private JsonDeserializer<ReferenceEntry> referenceDeserializer;
+
+	private Class<? extends EObjectSerializer> eObjectSerializerClass = EObjectSerializer.class;
+	private Class<? extends EObjectDeserializer> eObjectDeserializerClass = EObjectDeserializer.class;
 
 	public void setTypeInfo(EcoreTypeInfo info) {
 		this.typeInfo = info;
@@ -59,6 +66,14 @@ public class EMFModule extends SimpleModule {
 
 	public void setReferenceInfo(EcoreReferenceInfo referenceInfo) {
 		this.referenceInfo = referenceInfo;
+	}
+
+	public void setEnumeratorSerializer(JsonSerializer<?> serializer) {
+		this.enumeratorSerializer = serializer;
+	}
+
+	public JsonSerializer<?> getEnumeratorSerializer() {
+		return enumeratorSerializer;
 	}
 
 	public void setReferenceSerializer(JsonSerializer<EObject> serializer) {
@@ -75,6 +90,22 @@ public class EMFModule extends SimpleModule {
 
 	public JsonDeserializer<ReferenceEntry> getReferenceDeserializer() {
 		return referenceDeserializer;
+	}
+
+	public void setEObjectSerializerClass(Class<? extends EObjectSerializer> eObjectSerializerClass) {
+		this.eObjectSerializerClass = eObjectSerializerClass;
+	}
+
+	public Class<? extends EObjectSerializer> getEObjectSerializerClass() {
+		return eObjectSerializerClass;
+	}
+
+	public void setEObjectDeserializerClass(Class<? extends EObjectDeserializer> eObjectDeserializerClass) {
+		this.eObjectDeserializerClass = eObjectDeserializerClass;
+	}
+
+	public Class<? extends EObjectDeserializer> getEObjectDeserializerClass() {
+		return eObjectDeserializerClass;
 	}
 
 	/**
@@ -194,6 +225,10 @@ public class EMFModule extends SimpleModule {
 			referenceInfo = new EcoreReferenceInfo(handler);
 		}
 
+		if (enumeratorSerializer == null) {
+			enumeratorSerializer = new EnumeratorSerializer();
+		}
+		
 		if (referenceSerializer == null) {
 			referenceSerializer = new EcoreReferenceSerializer(referenceInfo, typeInfo);
 		}

--- a/src/main/java/org/emfjson/jackson/utils/ValueReader.java
+++ b/src/main/java/org/emfjson/jackson/utils/ValueReader.java
@@ -11,8 +11,14 @@
  */
 package org.emfjson.jackson.utils;
 
+import org.eclipse.emf.ecore.EObject;
+
 import com.fasterxml.jackson.databind.DeserializationContext;
 
 public interface ValueReader<V, T> {
 	T readValue(V value, DeserializationContext context);
+	
+	default T readValue(EObject eObject, V value, DeserializationContext context) {
+		return readValue(value, context);
+	}
 }

--- a/src/main/java/org/emfjson/jackson/utils/ValueWriter.java
+++ b/src/main/java/org/emfjson/jackson/utils/ValueWriter.java
@@ -11,8 +11,14 @@
  */
 package org.emfjson.jackson.utils;
 
+import org.eclipse.emf.ecore.EObject;
+
 import com.fasterxml.jackson.databind.SerializerProvider;
 
 public interface ValueWriter<T, V> {
 	V writeValue(T value, SerializerProvider context);
+	
+	default V writeValue(EObject eObject, T value, SerializerProvider context) {
+		return writeValue(value, context);
+	}
 }


### PR DESCRIPTION
These changes allow EMFJson to be used for data migration where fine grained control is required to provide special schema alignment. At the same time it doesn't impose any burden for normal users.

-Allow for extending EObject ser/deserializers
-Allow for extending enum serializer
-Adjusted scopes from private to protected in many places to help with
extending.
-Allow overriding feature in EObjectFeatureProperty
-Value reader and writer now pass in the EObject and not only the value
with defaults to existing pattern.