### PR TITLE
Fix infinite loop when object is given instead of array

### DIFF
--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/ReferenceTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/ReferenceTest.java
@@ -23,7 +23,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Paths;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -357,5 +359,17 @@ public class ReferenceTest {
       assertThat(resource.getContents())
          .hasSize(1)
          .hasOnlyElementsOfType(User.class);
+   }
+
+   @Test
+   public void testLoadObjectInsteadOfArray() {
+      try {
+         resourceSet.getResource(
+             URI.createURI("src/test/resources/tests/object-instead-of-array.json"), true);
+      } catch (final WrappedException e) {
+         final Throwable cause = e.getCause();
+         assertThat(cause).isInstanceOf(JsonParseException.class);
+         assertThat(cause.getMessage()).contains("Expected START_ARRAY token");
+      }
    }
 }

--- a/src/test/resources/tests/object-instead-of-array.json
+++ b/src/test/resources/tests/object-instead-of-array.json
@@ -1,0 +1,8 @@
+{
+  "eClass": "http://www.emfjson.org/jackson/model#//Node",
+  "label": "foo",
+  "child": {
+    "eClass": "http://www.emfjson.org/jackson/model#//Node",
+    "label": "bar"
+  }
+}


### PR DESCRIPTION
If a JSON contained an object instead of an array for a given reference that expects an array normally, the `EObjectDeserializer` will hang in an infinite loop eventually resulting in an out of memory error. 

This fixes the issue by throwing an exception, when an unexpected token is encountered while parsing a many-valued feature.

The bug can be reproduced with the added test case.

The bug is very similar to [this PR's solution](https://github.com/emfjson/emfjson-jackson/pull/106).
