### PR TITLE
Support custom data type (de)serialization with EFactory

### DIFF
--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/EDataTypeDeserializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/EDataTypeDeserializer.java
@@ -16,7 +16,6 @@ import static org.eclipse.emf.ecore.EcorePackage.Literals.EJAVA_OBJECT;
 import java.io.IOException;
 
 import org.eclipse.emf.ecore.EDataType;
-import org.eclipse.emf.ecore.EEnum;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emfcloud.jackson.databind.EMFContext;
 
@@ -25,6 +24,11 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 
 public class EDataTypeDeserializer extends JsonDeserializer<Object> {
+
+   public static boolean isJavaLangType(final EDataType dataType) {
+      String instanceClassName = dataType.getInstanceClassName();
+      return instanceClassName.startsWith("java.lang.") || instanceClassName.indexOf('.') < 0;
+   }
 
    @Override
    public Object deserialize(final JsonParser jp, final DeserializationContext ctxt) throws IOException {
@@ -35,7 +39,7 @@ public class EDataTypeDeserializer extends JsonDeserializer<Object> {
       }
       Class<?> type = dataType.getInstanceClass();
 
-      if (type == null || dataType instanceof EEnum || EJAVA_CLASS.equals(dataType)
+      if (type == null || (!isJavaLangType(dataType)) || EJAVA_CLASS.equals(dataType)
          || EJAVA_OBJECT.equals(dataType)) {
          return EcoreUtil.createFromString(dataType, jp.getText());
       }

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/ValueTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/ValueTest.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -400,5 +401,37 @@ public class ValueTest {
       JsonNode result = mapper.valueToTree(resource);
 
       assertThat(result.get("objectType").isNumber()).isTrue();
+   }
+
+   @Test
+   public void testLocalDateValue() {
+      Resource resource = resourceSet.createResource(URI.createURI("tests/test.json"));
+
+      ETypes valueObject = ModelFactory.eINSTANCE.createETypes();
+      valueObject.setELocalDate(LocalDate.of(2021, 9, 13));
+      resource.getContents().add(valueObject);
+
+      JsonNode result = mapper.valueToTree(resource);
+
+      assertEquals("2021-09-13", result.get("eLocalDate").asText());
+   }
+
+   @Test
+   public void testLoadLocalDateValue() throws IOException {
+      JsonNode data = mapper.createObjectNode()
+         .put("eClass", "http://www.emfjson.org/jackson/model#//ETypes")
+         .put("eLocalDate", "2021-09-13");
+
+      Resource resource = resourceSet.createResource(URI.createURI("tests/test.json"));
+      resource.load(new ByteArrayInputStream(mapper.writeValueAsBytes(data)), null);
+
+      assertEquals(1, resource.getContents().size());
+
+      EObject root = resource.getContents().get(0);
+      assertEquals(ModelPackage.Literals.ETYPES, root.eClass());
+
+      LocalDate value = ((ETypes) root).getELocalDate();
+
+      assertEquals(LocalDate.of(2021, 9, 13), value);
    }
 }

--- a/src/test/resources/model/model.xcore
+++ b/src/test/resources/model/model.xcore
@@ -11,6 +11,8 @@ package org.eclipse.emfcloud.jackson.junit.model
 import org.eclipse.emf.ecore.EByteArray
 import org.eclipse.emf.ecore.EFeatureMapEntry
 import java.util.Map
+import java.time.format.DateTimeFormatter
+import java.time.LocalDate
 
 class User {
 	id String userId
@@ -62,6 +64,7 @@ class ETypes {
 	contains StringMap[*] stringMapValues
 	contains DataTypeMap[*] dataTypeMapValues
 	unique URI[] uris
+	ELocalDate eLocalDate
 }
 
 class StringMap wraps Map.Entry {
@@ -96,6 +99,13 @@ type URI wraps org.eclipse.emf.common.util.URI
 type UserType wraps String
 type ObjectType wraps Object
 type ObjectArrayType wraps Object[]
+type ELocalDate wraps java.time.LocalDate
+	convert {
+		if (it === null) "" else DateTimeFormatter.ISO_LOCAL_DATE.format(it);
+	}
+	create {
+		if (it === null || it.trim().empty) null else LocalDate.parse(it, DateTimeFormatter.ISO_LOCAL_DATE);
+	}
 
 class PrimaryObject {
 	String name


### PR DESCRIPTION
The implementation uses EFactory (de)serialization for (built-in) types that are not known to be handled well in (emf)json, e.g. types implemented in the ecore package or involving java.lang classes.

Tests are implemented for a custom data type for LocalDate.