### PR TITLE
Json serialization of arrays

### DIFF
--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/type/EcoreTypeFactory.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/type/EcoreTypeFactory.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.emfcloud.jackson.databind.type;
 
+import static org.eclipse.emf.ecore.EcorePackage.Literals.EBYTE_ARRAY;
 import static org.eclipse.emf.ecore.EcorePackage.Literals.EJAVA_CLASS;
 import static org.eclipse.emf.ecore.EcorePackage.Literals.EJAVA_OBJECT;
 
@@ -143,13 +144,8 @@ public class EcoreTypeFactory {
       Class<?> rawType = classifier.getInstanceClass();
 
       if (classifier instanceof EDataType) {
-         if (rawType == null || classifier == EJAVA_CLASS || classifier == EJAVA_OBJECT) {
+         if (rawType == null || classifier == EJAVA_CLASS || classifier == EJAVA_OBJECT || classifier == EBYTE_ARRAY) {
             rawType = EcoreType.DataType.class;
-         } else {
-            // handle e.g. EByteArray byte[]
-            if (rawType.isArray()) {
-               rawType = EcoreType.DataType.class;
-            }
          }
       } else if (rawType == null) {
          rawType = EObject.class;

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/type/EcoreTypeFactory.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/type/EcoreTypeFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Guillaume Hillairet and others.
+ * Copyright (c) 2019-2022 Guillaume Hillairet and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/emfcloud/jackson/TestSuite.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/TestSuite.java
@@ -12,6 +12,7 @@ package org.eclipse.emfcloud.jackson;
 
 import org.eclipse.emfcloud.jackson.databind.type.EcoreTypeFactoryTest;
 import org.eclipse.emfcloud.jackson.tests.AnnotationTest;
+import org.eclipse.emfcloud.jackson.tests.ArrayTest;
 import org.eclipse.emfcloud.jackson.tests.ContainmentTest;
 import org.eclipse.emfcloud.jackson.tests.EnumTest;
 import org.eclipse.emfcloud.jackson.tests.ExternalReferencesTest;
@@ -60,6 +61,7 @@ import org.junit.runners.Suite.SuiteClasses;
    ReaderTest.class,
    ReferenceTest.class,
    ValueTest.class,
+   ArrayTest.class,
 
    // type factory
    EcoreTypeFactoryTest.class,
@@ -88,4 +90,5 @@ import org.junit.runners.Suite.SuiteClasses;
    CustomDeserializersTest.class,
    CustomSerializersTest.class
 })
+
 public class TestSuite {}

--- a/src/test/java/org/eclipse/emfcloud/jackson/TestSuite.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/TestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Guillaume Hillairet and others.
+ * Copyright (c) 2019-2022 Guillaume Hillairet and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/ArrayTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/ArrayTest.java
@@ -1,8 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Data In Motion Consulting GmbH and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
 package org.eclipse.emfcloud.jackson.tests;
 
-import static org.eclipse.emfcloud.jackson.module.EMFModule.Feature.OPTION_SERIALIZE_DEFAULT_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emfcloud.jackson.junit.array.ArrayFactory;
 import org.eclipse.emfcloud.jackson.junit.array.ArrayHost;
 import org.eclipse.emfcloud.jackson.support.StandardFixture;
@@ -19,6 +35,7 @@ public class ArrayTest {
    public static StandardFixture fixture = new StandardFixture();
 
    private final ObjectMapper mapper = fixture.mapper();
+   private final ResourceSet resourceSet = fixture.getResourceSet();
 
    @Test
    public void testByteArray() {
@@ -30,7 +47,7 @@ public class ArrayTest {
       expected.put("b", "0102");
 
       assertEquals(expected,
-         fixture.mapper(OPTION_SERIALIZE_DEFAULT_VALUE, true)
+         fixture.mapper()
             .valueToTree(u));
    }
 
@@ -45,8 +62,7 @@ public class ArrayTest {
       a.add(1.1).add(1.2);
 
       assertEquals(expected,
-         fixture.mapper(OPTION_SERIALIZE_DEFAULT_VALUE, true)
-            .valueToTree(u));
+         fixture.mapper().valueToTree(u));
    }
 
    @Test
@@ -61,7 +77,7 @@ public class ArrayTest {
       a.addArray().add(2.1).add(2.2);
 
       assertEquals(expected,
-         fixture.mapper(OPTION_SERIALIZE_DEFAULT_VALUE, true)
+         fixture.mapper()
             .valueToTree(u));
    }
 
@@ -81,7 +97,7 @@ public class ArrayTest {
       a2.addArray().add(2.21).add(2.22);
 
       assertEquals(expected,
-         fixture.mapper(OPTION_SERIALIZE_DEFAULT_VALUE, true)
+         fixture.mapper()
             .valueToTree(u));
    }
 
@@ -97,7 +113,46 @@ public class ArrayTest {
       a.addArray().add("2.1").add("2.2");
 
       assertEquals(expected,
-         fixture.mapper(OPTION_SERIALIZE_DEFAULT_VALUE, true)
+         fixture.mapper()
             .valueToTree(u));
    }
+
+   @Test
+   public void testLoad2DDoubleArrayValues() throws IOException {
+      String data = "{\n" +
+         "  \"eClass\": \"http://www.emfjson.org/jackson/model#//ArrayHost\",\n" +
+         "  \"d2\": [ \n" +
+         "    [1.1, 1.2], \n" +
+         "    [2.1, 2.2] ]\n" +
+         "}";
+
+      Resource resource = resourceSet.createResource(URI.createURI("tests/test.json"));
+      resource.load(new ByteArrayInputStream(data.getBytes()), null);
+
+      ArrayHost host = (ArrayHost) resource.getContents().get(0);
+      Double[][] d2 = host.getD2();
+      assertThat(d2).hasSize(2);
+      assertThat(d2[0]).containsExactly(1.1, 1.2);
+      assertThat(d2[1]).containsExactly(2.1, 2.2);
+   }
+
+   @Test
+   public void testLoad2DStringArrayValues() throws IOException {
+      String data = "{\n" +
+         "  \"eClass\": \"http://www.emfjson.org/jackson/model#//ArrayHost\",\n" +
+         "  \"s2\": [ \n" +
+         "    [\"1.1\", \"1.2\"], \n" +
+         "    [\"2.1\", \"2.2\"] ]\n" +
+         "}";
+
+      Resource resource = resourceSet.createResource(URI.createURI("tests/test.json"));
+      resource.load(new ByteArrayInputStream(data.getBytes()), null);
+
+      ArrayHost host = (ArrayHost) resource.getContents().get(0);
+      String[][] s2 = host.getS2();
+      assertThat(s2).hasSize(2);
+      assertThat(s2[0]).containsExactly("1.1", "1.2");
+      assertThat(s2[1]).containsExactly("2.1", "2.2");
+   }
+
 }

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/ArrayTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/ArrayTest.java
@@ -1,0 +1,103 @@
+package org.eclipse.emfcloud.jackson.tests;
+
+import static org.eclipse.emfcloud.jackson.module.EMFModule.Feature.OPTION_SERIALIZE_DEFAULT_VALUE;
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.emfcloud.jackson.junit.array.ArrayFactory;
+import org.eclipse.emfcloud.jackson.junit.array.ArrayHost;
+import org.eclipse.emfcloud.jackson.support.StandardFixture;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class ArrayTest {
+
+   @ClassRule
+   public static StandardFixture fixture = new StandardFixture();
+
+   private final ObjectMapper mapper = fixture.mapper();
+
+   @Test
+   public void testByteArray() {
+      ArrayHost u = ArrayFactory.eINSTANCE.createArrayHost();
+      u.setB(new byte[] { 1, 2 });
+
+      ObjectNode expected = mapper.createObjectNode()
+         .put("eClass", "http://www.emfjson.org/jackson/model#//ArrayHost");
+      expected.put("b", "0102");
+
+      assertEquals(expected,
+         fixture.mapper(OPTION_SERIALIZE_DEFAULT_VALUE, true)
+            .valueToTree(u));
+   }
+
+   @Test
+   public void test1DArray() {
+      ArrayHost u = ArrayFactory.eINSTANCE.createArrayHost();
+      u.setD1(new Double[] { 1.1, 1.2 });
+
+      ObjectNode expected = mapper.createObjectNode()
+         .put("eClass", "http://www.emfjson.org/jackson/model#//ArrayHost");
+      ArrayNode a = expected.putArray("d1");
+      a.add(1.1).add(1.2);
+
+      assertEquals(expected,
+         fixture.mapper(OPTION_SERIALIZE_DEFAULT_VALUE, true)
+            .valueToTree(u));
+   }
+
+   @Test
+   public void test2DArray() {
+      ArrayHost u = ArrayFactory.eINSTANCE.createArrayHost();
+      u.setD2(new Double[][] { { 1.1, 1.2 }, { 2.1, 2.2 } });
+
+      ObjectNode expected = mapper.createObjectNode()
+         .put("eClass", "http://www.emfjson.org/jackson/model#//ArrayHost");
+      ArrayNode a = expected.putArray("d2");
+      a.addArray().add(1.1).add(1.2);
+      a.addArray().add(2.1).add(2.2);
+
+      assertEquals(expected,
+         fixture.mapper(OPTION_SERIALIZE_DEFAULT_VALUE, true)
+            .valueToTree(u));
+   }
+
+   @Test
+   public void test3DArray() {
+      ArrayHost u = ArrayFactory.eINSTANCE.createArrayHost();
+      u.setD3(new Double[][][] { { { 1.11, 1.12 }, { 1.21, 1.22 } }, { { 2.11, 2.12 }, { 2.21, 2.22 } } });
+
+      ObjectNode expected = mapper.createObjectNode()
+         .put("eClass", "http://www.emfjson.org/jackson/model#//ArrayHost");
+      ArrayNode a = expected.putArray("d3");
+      ArrayNode a1 = a.addArray();
+      a1.addArray().add(1.11).add(1.12);
+      a1.addArray().add(1.21).add(1.22);
+      ArrayNode a2 = a.addArray();
+      a2.addArray().add(2.11).add(2.12);
+      a2.addArray().add(2.21).add(2.22);
+
+      assertEquals(expected,
+         fixture.mapper(OPTION_SERIALIZE_DEFAULT_VALUE, true)
+            .valueToTree(u));
+   }
+
+   @Test
+   public void test2DString() {
+      ArrayHost u = ArrayFactory.eINSTANCE.createArrayHost();
+      u.setS2(new String[][] { { "1.1", "1.2" }, { "2.1", "2.2" } });
+
+      ObjectNode expected = mapper.createObjectNode()
+         .put("eClass", "http://www.emfjson.org/jackson/model#//ArrayHost");
+      ArrayNode a = expected.putArray("s2");
+      a.addArray().add("1.1").add("1.2");
+      a.addArray().add("2.1").add("2.2");
+
+      assertEquals(expected,
+         fixture.mapper(OPTION_SERIALIZE_DEFAULT_VALUE, true)
+            .valueToTree(u));
+   }
+}

--- a/src/test/resources/model/array.xcore
+++ b/src/test/resources/model/array.xcore
@@ -1,0 +1,26 @@
+@Ecore(nsURI="http://www.emfjson.org/jackson/model")
+@GenModel(
+    modelDirectory="emfjson-jackson/src/test/java-gen",
+    updateClasspath="false",
+    bundleManifest="false",
+    rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl",
+    complianceLevel="8.0"
+)
+package org.eclipse.emfcloud.jackson.junit.array
+
+import org.eclipse.emf.ecore.EByteArray
+
+class ArrayHost {
+	double1D d1
+	double2D d2
+	double3D d3
+	string2D s2
+	EByteArray b
+}
+
+
+type double1D wraps Double[]
+type double2D wraps Double[][]
+type double3D wraps Double[][][]
+
+type string2D wraps String[][]


### PR DESCRIPTION
I have tried to use a 2 dimensional Double array in our ecore model 
`<eClassifiers xsi:type="ecore:EDataType" name="d2" instanceClassName="java.lang.Double[][]"/>` 
and expected something like:
`"d2":[[1.1,1.2],[2.1,2.2]]` 
as json but got:
`"d2":"ACED0005757200145B5B4C6A6176612E6C616E672E446F75626C653BD2F91EFA064A0BB0020000787000000002757200135B4C6A6176612E6C616E672E446F75626C653BE112AD8900A656A6020000787000000002737200106A6176612E6C616E672E446F75626C6580B3C24A296BFB0402000144000576616C7565787200106A6176612E6C616E672E4E756D62657286AC951D0B94E08B02000078703FF199999999999A7371007E00043FF33333333333337571007E0002000000027371007E00044000CCCCCCCCCCCD7371007E0004400199999999999A"`
The same issue occurs with every kind of object array.

As the cause of the problem I have identified a little bit to greedy rawType identification in the EcoreTypeFactory. For the EByteArray type it is fine to handle it as EcoreType.DataType, but for other arrays the serialization should go the usual way and drill down to the component types.