### PR TITLE
Make EMap serializer more configurable for NPE fix

### DIFF
--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMFSerializers.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMFSerializers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Guillaume Hillairet and others.
+ * Copyright (c) 2019-2022 Guillaume Hillairet and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -9,6 +9,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  *******************************************************************************/
 package org.eclipse.emfcloud.jackson.databind.ser;
+
+import java.util.Optional;
+import java.util.Set;
 
 import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.common.util.Enumerator;
@@ -27,6 +30,7 @@ import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.Serializers;
 import com.fasterxml.jackson.databind.ser.std.CollectionSerializer;
+import com.fasterxml.jackson.databind.ser.std.MapSerializer;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.databind.type.MapLikeType;
 
@@ -36,7 +40,8 @@ public class EMFSerializers extends Serializers.Base {
    private final JsonSerializer<EObject> referenceSerializer;
    private final JsonSerializer<Resource> resourceSerializer = new ResourceSerializer();
    private final JsonSerializer<?> dataTypeSerializer = new EDataTypeSerializer();
-   private final JsonSerializer<?> mapSerializer = new EMapStringSerializer();
+   private final JsonSerializer<Object> mapKeySerializer = new EMapKeySerializer();
+   private final JsonSerializer<Object> mapValueSerializer = new EMapValueSerializer();
    private final JsonSerializer<?> enumeratorSerializer = new EnumeratorSerializer();
 
    public EMFSerializers(final EMFModule module) {
@@ -50,9 +55,13 @@ public class EMFSerializers extends Serializers.Base {
       final TypeSerializer elementTypeSerializer,
       final JsonSerializer<Object> elementValueSerializer) {
       if (type.isTypeOrSubTypeOf(EMap.class)) {
-         if (type.getKeyType().isTypeOrSubTypeOf(String.class)) {
-            return mapSerializer;
-         }
+         // make a MapSerializer for configurability
+         JsonSerializer<Object> keySer = Optional.ofNullable(keySerializer).orElse(mapKeySerializer);
+         JsonSerializer<Object> valueSer = Optional.ofNullable(elementValueSerializer).orElse(mapValueSerializer);
+         MapSerializer mapSer = MapSerializer.construct(Set.of(), type, false, elementTypeSerializer, keySer, valueSer,
+            null);
+         // and use a wrapping EMapSerializer for edge cases
+         return new EMapSerializer(mapSer);
       }
 
       return super.findMapLikeSerializer(config, type, beanDesc, keySerializer, elementTypeSerializer,

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMapKeySerializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMapKeySerializer.java
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2022 CS GROUP and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.jackson.databind.ser;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.EMap;
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emfcloud.jackson.databind.EMFContext;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * Serializes keys of an {@link EMap}.
+ *
+ * @author vhemery
+ */
+public class EMapKeySerializer extends JsonSerializer<Object> {
+
+   @Override
+   public void serialize(final Object value, final JsonGenerator gen, final SerializerProvider serializers)
+      throws java.io.IOException {
+      EStructuralFeature feature = EMFContext.getFeature(serializers);
+      Optional<EReference> mapRef = Optional.ofNullable(feature).filter(EReference.class::isInstance)
+         .map(EReference.class::cast);
+      Optional<EStructuralFeature> keyFeature = mapRef.map(EReference::getEReferenceType)
+         .map(mapType -> mapType.getEStructuralFeature("key")).filter(Objects::nonNull);
+      Optional<EDataType> keyType = keyFeature.filter(EAttribute.class::isInstance).map(EAttribute.class::cast)
+         .map(EAttribute::getEAttributeType);
+      if (keyType.isPresent()) {
+         gen.writeFieldName(EcoreUtil.convertToString(keyType.get(), value));
+      } else {
+         // the metamodel is probably incorrect...
+         gen.writeFieldName(value.toString());
+      }
+   }
+}

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMapSerializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMapSerializer.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 CS GROUP and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+package org.eclipse.emfcloud.jackson.databind.ser;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.EMap;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.MapSerializer;
+
+/**
+ * An serializer for {@link EMap}, which delegates to {@link MapSerializer} for configurability.
+ *
+ * @author vhemery
+ */
+public class EMapSerializer extends JsonSerializer<EList<Map.Entry<?, ?>>> {
+
+   /** The Map serializer we delegate the job to. */
+   private final MapSerializer delegate;
+
+   public EMapSerializer(final MapSerializer delegateMapSerialize) {
+      this.delegate = delegateMapSerialize;
+   }
+
+   @SuppressWarnings({ "rawtypes", "unchecked" })
+   @Override
+   public void serialize(final EList<Map.Entry<?, ?>> value, final JsonGenerator jg,
+      final SerializerProvider serializers)
+      throws IOException {
+      if (value == null || value.isEmpty()) {
+         jg.writeNull();
+      } else if (value instanceof EMap) {
+         delegate.serialize(((EMap) value).map(), jg, serializers);
+      } else {
+         // iterate on entries manually
+         jg.writeStartObject();
+         for (Map.Entry<?, ?> entry : value) {
+            Object key = Optional.ofNullable((Object) entry.getKey()).orElse("");
+            ((JsonSerializer<Object>) delegate.getKeySerializer()).serialize(key, jg, serializers);
+            Object objectValue = entry.getValue();
+            ((JsonSerializer<Object>) delegate.getContentSerializer()).serialize(objectValue, jg, serializers);
+         }
+         jg.writeEndObject();
+      }
+   }
+
+}

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMapStringSerializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMapStringSerializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Guillaume Hillairet and others.
+ * Copyright (c) 2019-2022 Guillaume Hillairet and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,6 +19,11 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
+/**
+ * @deprecated use {@link EMapSerializer} instead for configurability and resilience.
+ * @see org.eclipse.emfcloud.jackson.databind.ser.EMFSerializers EMapSerializer example in findMapLikeSerializer.
+ */
+@Deprecated
 public class EMapStringSerializer extends JsonSerializer<EList<Map.Entry<String, ?>>> {
 
    @Override

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMapValueSerializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMapValueSerializer.java
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (c) 2022 CS GROUP and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.jackson.databind.ser;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.EMap;
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emfcloud.jackson.databind.EMFContext;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * Serializes values of an {@link EMap}.
+ *
+ * @author vhemery
+ */
+public class EMapValueSerializer extends JsonSerializer<Object> {
+
+   @Override
+   public void serialize(final Object value, final JsonGenerator gen, final SerializerProvider serializers)
+      throws java.io.IOException {
+      EStructuralFeature feature = EMFContext.getFeature(serializers);
+      Optional<EReference> mapRef = Optional.ofNullable(feature).filter(EReference.class::isInstance)
+         .map(EReference.class::cast);
+      Optional<EStructuralFeature> valueFeature = mapRef.map(EReference::getEReferenceType)
+         .map(mapType -> mapType.getEStructuralFeature("value")).filter(Objects::nonNull);
+      Optional<EDataType> valueDataType = valueFeature.filter(EAttribute.class::isInstance).map(EAttribute.class::cast)
+         .map(EAttribute::getEAttributeType);
+      Optional<EClass> valueEClass = valueFeature.filter(EReference.class::isInstance).map(EReference.class::cast)
+         .map(EReference::getEReferenceType);
+      if (valueDataType.isPresent()) {
+         gen.writeString(EcoreUtil.convertToString(valueDataType.get(), value));
+      } else if (valueEClass.isPresent() && value instanceof EObject) {
+         gen.writeObject(value);
+      } else {
+         // the metamodel is probably incorrect...
+         gen.writeString(value.toString());
+      }
+   }
+}

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/NullKeySerializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/NullKeySerializer.java
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (c) 2022 CS GROUP and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.jackson.databind.ser;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Serializes a null key in an EMap.
+ *
+ * @author vhemery
+ */
+public class NullKeySerializer extends StdSerializer<Object> {
+
+   /** Default serial UID. */
+   private static final long serialVersionUID = 1L;
+
+   /**
+    * Constructs a new Null key serializer.
+    */
+   public NullKeySerializer() {
+      super(null, false);
+   }
+
+   @Override
+   public void serialize(final Object nullKey, final JsonGenerator gen, final SerializerProvider serializers)
+      throws java.io.IOException {
+      gen.writeFieldName("");
+   }
+}

--- a/src/main/java/org/eclipse/emfcloud/jackson/module/EMFModule.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/module/EMFModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Guillaume Hillairet and others.
+ * Copyright (c) 2019-2022 Guillaume Hillairet and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,6 +23,7 @@ import org.eclipse.emfcloud.jackson.databind.deser.EcoreReferenceDeserializer;
 import org.eclipse.emfcloud.jackson.databind.deser.ReferenceEntry;
 import org.eclipse.emfcloud.jackson.databind.ser.EMFSerializers;
 import org.eclipse.emfcloud.jackson.databind.ser.EcoreReferenceSerializer;
+import org.eclipse.emfcloud.jackson.databind.ser.NullKeySerializer;
 import org.eclipse.emfcloud.jackson.handlers.BaseURIHandler;
 import org.eclipse.emfcloud.jackson.handlers.URIHandler;
 
@@ -153,6 +154,8 @@ public class EMFModule extends SimpleModule {
       mapper.setDateFormat(dateFormat);
       mapper.setTimeZone(TimeZone.getDefault());
       mapper.registerModule(new EMFModule());
+      // add default serializer for null EMap key
+      mapper.getSerializerProvider().setNullKeySerializer(new NullKeySerializer());
 
       return mapper;
    }

--- a/src/test/java/org/eclipse/emfcloud/jackson/support/StandardFixture.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/support/StandardFixture.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Guillaume Hillairet and others.
+ * Copyright (c) 2019-2022 Guillaume Hillairet and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -21,6 +21,7 @@ import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+import org.eclipse.emfcloud.jackson.databind.ser.NullKeySerializer;
 import org.eclipse.emfcloud.jackson.junit.generics.GenericsPackage;
 import org.eclipse.emfcloud.jackson.junit.model.ModelPackage;
 import org.eclipse.emfcloud.jackson.module.EMFModule;
@@ -79,6 +80,8 @@ public class StandardFixture extends ExternalResource {
 
       mapper.setDateFormat(dateFormat);
       mapper.setTimeZone(TimeZone.getDefault());
+      // add default serializer for null EMap key
+      mapper.getSerializerProvider().setNullKeySerializer(new NullKeySerializer());
 
       return mapper;
    }

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/MapTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/MapTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Guillaume Hillairet and others.
+ * Copyright (c) 2019-2022 Guillaume Hillairet and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -225,5 +225,24 @@ public class MapTest {
          .isNotNull();
       assertThat(types.getDataTypeMapValues().map())
          .contains(entry("test.json", "hello"));
+   }
+
+   /**
+    * Test the edge case when an EMap has an entry with null key
+    * (not compatible with json)
+    */
+   @Test
+   public void testSaveMapWithNullKey() {
+      JsonNode expected = mapper.createObjectNode()
+         .put("eClass", "http://www.emfjson.org/jackson/model#//ETypes")
+         .set("dataTypeMapValues", mapper.createObjectNode()
+            .put("", "hello"));
+
+      ETypes types = ModelFactory.eINSTANCE.createETypes();
+      types.getDataTypeMapValues().put(null, "hello");
+
+      JsonNode actual = mapper.valueToTree(types);
+      assertThat(actual)
+         .isEqualTo(expected);
    }
 }

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/ModelTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/ModelTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Guillaume Hillairet and others.
+ * Copyright (c) 2019-2022 Guillaume Hillairet and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -30,6 +30,7 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emfcloud.jackson.databind.ser.NullKeySerializer;
 import org.eclipse.emfcloud.jackson.module.EMFModule;
 import org.eclipse.emfcloud.jackson.resource.JsonResourceFactory;
 import org.junit.Before;
@@ -60,6 +61,8 @@ public class ModelTest {
       dateFormat.setTimeZone(TimeZone.getDefault());
 
       mapper.setDateFormat(dateFormat);
+      // add default serializer for null EMap key
+      mapper.getSerializerProvider().setNullKeySerializer(new NullKeySerializer());
 
       resourceSet.getURIConverter()
          .getURIMap()


### PR DESCRIPTION
Deprecate EMapStringSerializer (keep it for external usages).
Use EMapSerializer instead, more generic and delegates to Jackson
MapSerializer for configurability.
Configure by default with NullKeySerializer using '' for null EMap keys.
(hence no more NPE)

closes https://github.com/eclipse-emfcloud/emfjson-jackson/issues/32