### PR TITLE
Try and insert Bundle-SymbolicName for bnd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
 						</executions>
 						<configuration>
 							<bnd><![CDATA[
+Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
 Import-Package: com.fasterxml.jackson.*;version="[2.6.0,3.0.0)",\
 	*
 Export-Package: org.eclipse.emfcloud.jackson.*


### PR DESCRIPTION
Bnd has artifactId as default BSN, which differs from previous behavior.
Try and tell BSN to bnd, hoping P2 update site publication will follow.

closes https://github.com/eclipse-emfcloud/emfjson-jackson/issues/34