### PR TITLE
Keep EcoreTypeInfo configuration for `@JsonType` annotations

### DIFF
--- a/src/main/java/org/eclipse/emfcloud/jackson/annotations/JsonAnnotations.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/annotations/JsonAnnotations.java
@@ -75,13 +75,25 @@ public final class JsonAnnotations {
     * @param classifier any classifier
     * @return the type information property
     */
-   @SuppressWarnings("checkstyle:cyclomaticComplexity")
    public static EcoreTypeInfo getTypeProperty(final EClassifier classifier) {
+      return getTypeProperty(classifier, null, null);
+   }
+
+
+   /**
+    * Returns the property that should be use to store the type information of the classifier.
+    *
+    * @param classifier  any classifier
+    * @param valueReader the reader to use for deserializing type info
+    * @param valueWriter the reader to use for serializing type info
+    * @return the type information property
+    */
+   @SuppressWarnings("checkstyle:cyclomaticComplexity")
+   public static EcoreTypeInfo getTypeProperty(final EClassifier classifier,
+                                               ValueReader<String, EClass> valueReader,
+                                               ValueWriter<EClass, String> valueWriter) {
       String property = getValue(classifier, "JsonType", "property");
       String use = getValue(classifier, "JsonType", "use");
-
-      ValueReader<String, EClass> valueReader = EcoreTypeInfo.DEFAULT_VALUE_READER;
-      ValueWriter<EClass, String> valueWriter = EcoreTypeInfo.DEFAULT_VALUE_WRITER;
 
       if (use != null) {
          EcoreTypeInfo.USE useType = EcoreTypeInfo.USE.valueOf(use.toUpperCase());
@@ -106,9 +118,6 @@ public final class JsonAnnotations {
                return type;
             };
             valueWriter = (value, context) -> value.getInstanceClassName();
-         } else {
-            valueReader = EcoreTypeInfo.DEFAULT_VALUE_READER;
-            valueWriter = EcoreTypeInfo.DEFAULT_VALUE_WRITER;
          }
       }
 

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectPropertyMap.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectPropertyMap.java
@@ -193,7 +193,7 @@ public final class EObjectPropertyMap {
          EcoreTypeInfo currentTypeInfo = null;
 
          if (type != null && !JsonAnnotations.shouldIgnoreType(type)) {
-            currentTypeInfo = JsonAnnotations.getTypeProperty(type);
+            currentTypeInfo = JsonAnnotations.getTypeProperty(type, typeInfo.getValueReader(), typeInfo.getValueWriter());
          }
 
          if (currentTypeInfo == null) {

--- a/src/test/resources/model/annotations.xcore
+++ b/src/test/resources/model/annotations.xcore
@@ -66,6 +66,11 @@ class TestF {
 	String otherValue
 }
 
+@JsonType(property="@type")
+class TestG {
+    String value
+}
+
 class Container {
 	contains TestTypeName[] typedByNames
 	contains TestTypeClass[] typedByClasses


### PR DESCRIPTION
When a `@JsonType` annotation is used to configure a different `property` to extract the type info, the `ValueReader` and `ValueWriter` functions to (de)serialize the property's content can only be configured using `use = "CLASS"` or `use = "NAME"`.

However, when configuring the `EMFModule` using a custom `EcoreTypeInfo` object, one can specify arbitrary functions to (de)serialize the type.

This change will copy the default `EcoreTypeInfo` configuration of the `EMFModule` to any `EcoreTypeInfo` instances that have been configured using annotations in the model. This will not change anything for places where a `use = ...` annotation detail is in place.

Closes https://github.com/eclipse-emfcloud/emfjson-jackson/issues/43
