### PR TITLE
Add `@JsonRawValue` annotation

### DIFF
--- a/src/main/java/org/eclipse/emfcloud/jackson/annotations/JsonAnnotations.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/annotations/JsonAnnotations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2021 Guillaume Hillairet and others.
+ * Copyright (c) 2019-2022 Guillaume Hillairet and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.emf.ecore.EAnnotation;
+import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.ENamedElement;
@@ -145,6 +146,18 @@ public final class JsonAnnotations {
     */
    public static String getIdentityProperty(final EClassifier classifier) {
       return getValue(classifier, "JsonIdentity", "property");
+   }
+
+   /**
+    * Returns {@code true}, if the feature is annotated to be treated as raw JSON.
+    *
+    * @param feature any feature
+    * @return {@code true}, if raw (de)serialization should be done for this feature
+    */
+   public static boolean isRawValue(final EStructuralFeature feature) {
+      return Boolean.parseBoolean(getValue(feature, "JsonRawValue", "value"))
+            && feature instanceof EAttribute
+            && String.class.getName().equals(feature.getEType().getInstanceClassName());
    }
 
    protected static String getValue(final ENamedElement element, final String annotation, final String property) {

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/RawDeserializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/RawDeserializer.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Jan Hicken.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+package org.eclipse.emfcloud.jackson.databind.deser;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+public class RawDeserializer extends JsonDeserializer<Object> {
+   @Override
+   public Object deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
+      final StringWriter writer = new StringWriter();
+      final JsonGenerator generator = p.getCodec().getFactory().createGenerator(writer);
+      final JsonNode tree = p.readValueAsTree();
+      generator.writeTree(tree);
+
+      return writer.toString();
+   }
+
+   @Override
+   public boolean isCachable() {
+      return true;
+   }
+}

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/annotations/JsonRawValueTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/annotations/JsonRawValueTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2019-2022 Guillaume Hillairet and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+package org.eclipse.emfcloud.jackson.tests.annotations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emfcloud.jackson.junit.annotations.AnnotationsPackage;
+import org.eclipse.emfcloud.jackson.junit.annotations.RawJson;
+import org.eclipse.emfcloud.jackson.module.EMFModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonRawValueTest {
+
+   private ObjectMapper mapper;
+
+   @Before
+   public void setUp() {
+      EPackage.Registry.INSTANCE.put(EcorePackage.eNS_URI, EcorePackage.eINSTANCE);
+      EPackage.Registry.INSTANCE.put(AnnotationsPackage.eNS_URI, AnnotationsPackage.eINSTANCE);
+
+      mapper = new ObjectMapper();
+      mapper.registerModule(new EMFModule());
+   }
+
+   @After
+   public void tearDown() {
+      EPackage.Registry.INSTANCE.clear();
+      Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().clear();
+   }
+
+   @Test
+   public void test_deserializeRaw() throws IOException {
+      final JsonNode input = mapper.createObjectNode()
+            .put("eClass", "http://www.emfjson.org/jackson/annotations#//RawJson")
+            .set("raw", mapper.createObjectNode()
+                  .put("foo", "bar"));
+
+      final RawJson raw = mapper.readValue(input.toString(), RawJson.class);
+      assertThat(raw.getRaw()).containsSubsequence("\"foo\":\"bar\"");
+   }
+
+   @Test
+   public void test_deserializeRawNull() throws IOException {
+      final JsonNode input = mapper.createObjectNode()
+            .put("eClass", "http://www.emfjson.org/jackson/annotations#//RawJson")
+            .putNull("raw");
+
+      final RawJson raw = mapper.readValue(input.toString(), RawJson.class);
+      assertThat(raw.getRaw()).isNull();
+   }
+}

--- a/src/test/resources/model/annotations.xcore
+++ b/src/test/resources/model/annotations.xcore
@@ -14,6 +14,7 @@ annotation "JsonIgnoreProperties" as JsonIgnoreProperties
 annotation "JsonType" as JsonType
 annotation "JsonIdentity" as JsonIdentity
 annotation "JsonAlias" as JsonAlias
+annotation "JsonRawValue" as JsonRawValue
 
 @JsonType(property = "@type")
 class TestA {
@@ -104,4 +105,9 @@ class FooTypeClass extends TestTypeClass {
 
 class BarTypeClass extends TestTypeClass {
 
+}
+
+class RawJson {
+    @JsonRawValue(value="true")
+    String raw
 }


### PR DESCRIPTION
The annotation triggers raw JSON (de)serialization for attributes, if their instance class is `java.lang.String`.

The serialization implementation matches the behaviour of `com.fasterxml.jackson.annotation.JsonRawValue`.

Unlike Jackson's implementation, deserialization of raw JSON into the String is also supported.

Closes https://github.com/eclipse-emfcloud/emfjson-jackson/issues/46

