### PR TITLE
Reset context parent after deserialisation of array

### DIFF
--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/ResourceDeserializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/ResourceDeserializer.java
@@ -68,6 +68,7 @@ public class ResourceDeserializer extends JsonDeserializer<Resource> {
             if (value != null) {
                resource.getContents().add(value);
             }
+            EMFContext.setParent(ctxt, null);
          }
 
       } else if (jp.getCurrentToken() == JsonToken.START_OBJECT) {

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/ReferenceTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/ReferenceTest.java
@@ -22,13 +22,15 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emfcloud.jackson.databind.EMFContext;
 import org.eclipse.emfcloud.jackson.junit.model.ModelFactory;
 import org.eclipse.emfcloud.jackson.junit.model.ModelPackage;
 import org.eclipse.emfcloud.jackson.junit.model.PrimaryObject;
@@ -39,6 +41,7 @@ import org.eclipse.emfcloud.jackson.support.StandardFixture;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -352,6 +355,50 @@ public class ReferenceTest {
    }
 
    @Test
+   public void testLoadArrayInArrayWithRootElement() throws IOException {
+      Resource resource = resourceSet
+         .createResource(URI.createURI("src/test/resources/tests/array-containing-array-without-eclass.json"));
+      Map<Object, Object> loadOption = new HashMap<>();
+      loadOption.put(EMFContext.Attributes.ROOT_ELEMENT, ModelPackage.Literals.PRIMARY_OBJECT);
+      resource.load(loadOption);
+
+      assertThat(resource.getContents())
+         .hasSize(3)
+         .hasOnlyElementsOfType(PrimaryObject.class);
+
+      PrimaryObject p1 = (PrimaryObject) resource.getContents().get(0);
+      assertThat(p1.getName())
+         .isEqualTo("p1");
+      assertThat(p1.getMultipleContainmentReferenceNoProxies())
+         .hasSize(2);
+      assertThat(p1.getMultipleContainmentReferenceNoProxies().get(0).getSingleAttribute())
+         .isEqualTo("t1");
+      assertThat(p1.getMultipleContainmentReferenceNoProxies().get(1).getSingleAttribute())
+         .isEqualTo("t2");
+
+      PrimaryObject p2 = (PrimaryObject) resource.getContents().get(1);
+      assertThat(p2.getName())
+         .isEqualTo("p2");
+      assertThat(p2.getMultipleContainmentReferenceNoProxies())
+         .hasSize(2);
+      assertThat(p2.getMultipleContainmentReferenceNoProxies().get(0).getSingleAttribute())
+         .isEqualTo("t3");
+      assertThat(p2.getMultipleContainmentReferenceNoProxies().get(1).getSingleAttribute())
+         .isEqualTo("t4");
+
+      PrimaryObject p3 = (PrimaryObject) resource.getContents().get(2);
+      assertThat(p3.getName())
+         .isEqualTo("p3");
+
+      assertThat(p3.getMultipleContainmentReferenceNoProxies())
+         .hasSize(2);
+      assertThat(p3.getMultipleContainmentReferenceNoProxies().get(0).getSingleAttribute())
+         .isEqualTo("t5");
+      assertThat(p3.getMultipleContainmentReferenceNoProxies().get(1).getSingleAttribute())
+         .isEqualTo("t6");
+   }
+
+   @Test
    public void testLoadArrayInsteadOfObject() throws IOException {
       final Resource resource = resourceSet.getResource(
          URI.createURI("src/test/resources/tests/array-instead-of-object.json"), true);
@@ -365,7 +412,7 @@ public class ReferenceTest {
    public void testLoadObjectInsteadOfArray() {
       try {
          resourceSet.getResource(
-             URI.createURI("src/test/resources/tests/object-instead-of-array.json"), true);
+            URI.createURI("src/test/resources/tests/object-instead-of-array.json"), true);
       } catch (final WrappedException e) {
          final Throwable cause = e.getCause();
          assertThat(cause).isInstanceOf(JsonParseException.class);

--- a/src/test/resources/tests/array-containing-array-without-eclass.json
+++ b/src/test/resources/tests/array-containing-array-without-eclass.json
@@ -1,0 +1,35 @@
+[
+	{
+		"name": "p1",
+		"multipleContainmentReferenceNoProxies": [
+			{
+				"singleAttribute": "t1"
+			},
+			{
+				"singleAttribute": "t2"
+			}
+		]
+	},
+	{
+		"name": "p2",
+		"multipleContainmentReferenceNoProxies": [
+			{
+				"singleAttribute": "t3"
+			},
+			{
+				"singleAttribute": "t4"
+			}
+		]
+	},
+	{
+		"name": "p3",
+		"multipleContainmentReferenceNoProxies": [
+			{
+				"singleAttribute": "t5"
+			},
+			{
+				"singleAttribute": "t6"
+			}
+		]
+	}
+]


### PR DESCRIPTION
I have encountered a problem when deserialising arrays that contain arrays.

```
[
	{
		name="n1",
		b=[
			{
				attr="a11"
			},
			{
				attr="a12"
			}
		]
	},
	{
		name="n2",
		b=[
			{
				attr="a21"
			},
			{
				attr="a22"
			}
		]
	}
]

```
 If the Root_Element is of type A and the elements of the containing b are from type B. The deserialisation of the first A element works fine and results in an object of type A but the 2nd A element is deserialised as an object of type B.

Findings: While traversing down the json in the parent is set on the context (EObjectFeatureProperty line 90) but not reset after array end.

Signed-off-by: Guido Grune <g.grune@datainmotion.com>