### PR TITLE
Introduce setting for using ExtendedMetaData names

### DIFF
--- a/src/main/java/org/eclipse/emfcloud/jackson/annotations/JsonAnnotations.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/annotations/JsonAnnotations.java
@@ -12,6 +12,7 @@ package org.eclipse.emfcloud.jackson.annotations;
 
 import static org.eclipse.emfcloud.jackson.annotations.EcoreTypeInfo.USE.CLASS;
 import static org.eclipse.emfcloud.jackson.annotations.EcoreTypeInfo.USE.NAME;
+import static org.eclipse.emfcloud.jackson.module.EMFModule.Feature.OPTION_USE_NAMES_FROM_EXTENDED_META_DATA;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,11 +40,12 @@ public final class JsonAnnotations {
     * Returns the name that should be use to serialize the property.
     *
     * @param element any element
+    * @param features the EMF module's feature flags
     * @return name of property
     */
-   public static String getElementName(final ENamedElement element) {
+   public static String getElementName(final ENamedElement element, final int features) {
       String value = getValue(element, "JsonProperty", "value");
-      if (value == null) {
+      if (value == null && OPTION_USE_NAMES_FROM_EXTENDED_META_DATA.enabledIn(features)) {
          value = getValue(element, EXTENDED_METADATA, "name");
       }
 

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectFeatureProperty.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectFeatureProperty.java
@@ -49,7 +49,7 @@ public class EObjectFeatureProperty extends EObjectProperty {
    private JsonDeserializer<Object> deserializer;
 
    public EObjectFeatureProperty(final EStructuralFeature feature, final JavaType type, final int features) {
-      super(getElementName(feature));
+      super(getElementName(feature, features));
 
       this.feature = feature;
       this.javaType = type;

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectPropertyMap.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectPropertyMap.java
@@ -137,7 +137,7 @@ public final class EObjectPropertyMap {
                EAnnotation annotation = operation.getEAnnotation("JsonProperty");
 
                if (annotation != null && operation.getEParameters().isEmpty()) {
-                  add.accept(new EObjectOperationProperty(getElementName(operation), operation));
+                  add.accept(new EObjectOperationProperty(getElementName(operation, features), operation));
                }
             }
          }

--- a/src/main/java/org/eclipse/emfcloud/jackson/module/EMFModule.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/module/EMFModule.java
@@ -90,7 +90,14 @@ public class EMFModule extends SimpleModule {
        * Option used to indicate the module to serialize default attributes values.
        * Default values are not serialized by default.
        */
-      OPTION_SERIALIZE_DEFAULT_VALUE(false);
+      OPTION_SERIALIZE_DEFAULT_VALUE(false),
+
+      /**
+       * Option used to indicate whether feature names specified in
+       * {@link org.eclipse.emf.ecore.util.ExtendedMetaData} annotations should
+       * be respected.
+       */
+      OPTION_USE_NAMES_FROM_EXTENDED_META_DATA(true);
 
       private final boolean defaultState;
       private final int mask;

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/ExtendedMetaDataTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/ExtendedMetaDataTest.java
@@ -1,0 +1,58 @@
+package org.eclipse.emfcloud.jackson.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.emfcloud.jackson.junit.model.Author;
+import org.eclipse.emfcloud.jackson.junit.model.Book;
+import org.eclipse.emfcloud.jackson.junit.model.ModelFactory;
+import org.eclipse.emfcloud.jackson.module.EMFModule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExtendedMetaDataTest {
+
+   @Test
+   public void testNoExtendedMetaDataNames() {
+      final EMFModule emfModule = new EMFModule();
+      emfModule.configure(EMFModule.Feature.OPTION_USE_NAMES_FROM_EXTENDED_META_DATA, false);
+      final ObjectMapper mapper = new ObjectMapper().registerModule(emfModule);
+
+      final Book book = ModelFactory.eINSTANCE.createBook();
+      book.setAuthorName("Friedrich Schiller");
+
+      final Author author = ModelFactory.eINSTANCE.createAuthor();
+      author.setFirstName("Friedrich");
+      author.setLastName("Schiller");
+      book.setAuthor(author);
+
+      final JsonNode json = mapper.valueToTree(book);
+      assertEquals("Friedrich Schiller", json.get("authorName").asText());
+      assertEquals("Friedrich", json.get("author").get("firstName").asText());
+      assertEquals("Schiller", json.get("author").get("lastName").asText());
+   }
+
+   @Test
+   public void testDefaultExtendedMetaDataNames() {
+      final ObjectMapper mapper = EMFModule.setupDefaultMapper();
+
+      final Book book = ModelFactory.eINSTANCE.createBook();
+      book.setAuthorName("Friedrich Schiller");
+
+      final JsonNode json = mapper.valueToTree(book);
+      assertEquals("Friedrich Schiller", json.get("author").asText());
+   }
+
+   @Test
+   public void testExtendedMetaDataNames() {
+      final EMFModule emfModule = new EMFModule();
+      emfModule.configure(EMFModule.Feature.OPTION_USE_NAMES_FROM_EXTENDED_META_DATA, true);
+      final ObjectMapper mapper = new ObjectMapper().registerModule(emfModule);
+
+      final Book book = ModelFactory.eINSTANCE.createBook();
+      book.setAuthorName("Friedrich Schiller");
+
+      final JsonNode json = mapper.valueToTree(book);
+      assertEquals("Friedrich Schiller", json.get("author").asText());
+   }
+}

--- a/src/test/resources/model/model.xcore
+++ b/src/test/resources/model/model.xcore
@@ -191,3 +191,17 @@ abstract class AbstractNode {
 class PhysicalNode extends AbstractNode {}
 
 class VirtualNode extends AbstractNode {}
+
+class Book {
+    contains Author author
+
+    @ExtendedMetaData(name="author")
+    String authorName
+
+    String title
+}
+
+class Author {
+    String firstName
+    String lastName
+}


### PR DESCRIPTION
The new `OPTION_USE_NAMES_FROM_EXTENDED_META_DATA` feature allows to
configure, if property names should be extracted from `ExtendedMetaData`
annotations.

It is enabled by default to maintain current behaviour.

When dealing with XML and Ecore models, that are generated from an XML
schema definition (XSD), the following example can occcur:

```xml
<foo bar="42">
  <bar baz="hello"/>
</foo>
```

Here, the element `<foo>` has both an attribute as well as a child
element called `bar`. A derived Ecore model would have two features,
where of those has a counter appended to remove ambiguity:

```java
interface Foo {
  /* Has @ExtendedMetadata(name="bar") */
  int getBar();

  /* Has @ExtendedMetadata(name="bar") */
  Bar getBar1();
}
```

The JSON mapper, however, will only serialize one of the two features
listed above, because it does not resolve the ambiguity of feature
names.

By disabling the newly introduced option, the internal feature names
would be used instead.

This fixes https://github.com/eclipse-emfcloud/emfjson-jackson/issues/54
