### PR TITLE
Make concurrently used caches thread-safe

### DIFF
--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectPropertyMap.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectPropertyMap.java
@@ -18,6 +18,7 @@ import static org.eclipse.emfcloud.jackson.annotations.JsonAnnotations.getAliase
 import static org.eclipse.emfcloud.jackson.annotations.JsonAnnotations.getElementName;
 import static org.eclipse.emfcloud.jackson.module.EMFModule.Feature.OPTION_USE_ID;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -56,7 +57,7 @@ public final class EObjectPropertyMap {
 
    public static class Builder {
 
-      private final Map<EClass, EObjectPropertyMap> cache = new WeakHashMap<>();
+      private final Map<EClass, EObjectPropertyMap> cache = Collections.synchronizedMap(new WeakHashMap<>());
 
       private final EcoreIdentityInfo identityInfo;
       private final EcoreTypeInfo typeInfo;

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/type/EcoreTypeFactory.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/type/EcoreTypeFactory.java
@@ -16,6 +16,7 @@ import static org.eclipse.emf.ecore.EcorePackage.Literals.EJAVA_CLASS;
 import static org.eclipse.emf.ecore.EcorePackage.Literals.EJAVA_OBJECT;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
@@ -34,7 +35,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 
 public class EcoreTypeFactory {
 
-   private final Map<Pair<EClass, EStructuralFeature>, JavaType> cache = new WeakHashMap<>();
+   private final Map<Pair<EClass, EStructuralFeature>, JavaType> cache = Collections.synchronizedMap(new WeakHashMap<>());
 
    private static class Pair<A, B> {
       private final A a;


### PR DESCRIPTION
Make concurrently used caches thread-safe

The thread safety is achieved by using `Collections.synchronizedMap()`.

This fixes https://github.com/eclipse-emfcloud/emfjson-jackson/issues/56
