### PR TITLE
Mapping FeatureMapEntries to JSON

### DIFF
--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/FeatureMapEntryConfig.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/FeatureMapEntryConfig.java
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.jackson.databind;
+
+import static org.eclipse.emfcloud.jackson.annotations.JsonAnnotations.getElementName;
+import static org.eclipse.emfcloud.jackson.module.EMFModule.Feature.OPTION_USE_FEATURE_MAP_KEY_AND_VALUE_PROPERTIES;
+
+import org.eclipse.emf.ecore.EStructuralFeature;
+
+/**
+ * Helps with feature map entries (de)serialization by taking care of configurable options.
+ */
+public class FeatureMapEntryConfig {
+
+   /** The json property used to store the entry's value. */
+   public static final String VALUE_PROPERTY = "value";
+   /** The json property used to store the entry's key (feature name). */
+   public static final String KEY_PROPERTY = "featureName";
+   /** The activated features from module. */
+   private final int features;
+
+   public FeatureMapEntryConfig(final int features) {
+      this.features = features;
+   }
+
+   /**
+    * Test whether we should use dedicated {@link FeatureMapEntryConfig#KEY_PROPERTY} and
+    * {@link FeatureMapEntryConfig#VALUE_PROPERTY} properties for feature map entries.
+    *
+    * @return true when using properties, false otherwise (default)
+    */
+   public boolean shouldUseKeyAndValueProperties() {
+      return OPTION_USE_FEATURE_MAP_KEY_AND_VALUE_PROPERTIES.enabledIn(features);
+   }
+
+   /**
+    * Get the name to use as property key or value (for {@link FeatureMapEntryConfig#VALUE_PROPERTY}) for the
+    * feature.
+    *
+    * @param feature a feature in map keys
+    * @return the name to use
+    */
+   public String getPropertyName(final EStructuralFeature feature) {
+      return getElementName(feature, features);
+   }
+
+}

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/EMFDeserializers.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/EMFDeserializers.java
@@ -17,6 +17,8 @@ import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.FeatureMap;
+import org.eclipse.emf.ecore.util.FeatureMap.Entry;
 import org.eclipse.emfcloud.jackson.databind.property.EObjectPropertyMap;
 import org.eclipse.emfcloud.jackson.databind.type.EcoreType;
 import org.eclipse.emfcloud.jackson.module.EMFModule;
@@ -39,6 +41,7 @@ public class EMFDeserializers extends Deserializers.Base {
    private final JsonDeserializer<EList<Map.Entry<?, ?>>> mapDeserializer;
    private final JsonDeserializer<Object> dataTypeDeserializer;
    private final JsonDeserializer<ReferenceEntry> referenceDeserializer;
+   private final JsonDeserializer<Entry> featureMapEntryDeserializer;
    private final EObjectPropertyMap.Builder builder;
 
    public EMFDeserializers(final EMFModule module) {
@@ -49,6 +52,7 @@ public class EMFDeserializers extends Deserializers.Base {
          module.getFeatures());
       this.resourceDeserializer = new ResourceDeserializer(module.getUriHandler());
       this.referenceDeserializer = module.getReferenceDeserializer();
+      this.featureMapEntryDeserializer = module.getFeatureMapEntryDeserializer();
       this.mapDeserializer = new EMapDeserializer();
       this.dataTypeDeserializer = new EDataTypeDeserializer();
    }
@@ -121,6 +125,10 @@ public class EMFDeserializers extends Deserializers.Base {
 
       if (type.isTypeOrSubTypeOf(EObject.class)) {
          return new EObjectDeserializer(builder, type.getRawClass());
+      }
+
+      if (type.isTypeOrSubTypeOf(FeatureMap.Entry.class)) {
+         return featureMapEntryDeserializer;
       }
 
       return super.findBeanDeserializer(type, config, beanDesc);

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/EcoreReferenceDeserializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/EcoreReferenceDeserializer.java
@@ -17,6 +17,7 @@ import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emfcloud.jackson.annotations.EcoreReferenceInfo;
 import org.eclipse.emfcloud.jackson.annotations.EcoreTypeInfo;
 import org.eclipse.emfcloud.jackson.databind.EMFContext;
+import org.eclipse.emfcloud.jackson.utils.EObjects;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -50,8 +51,11 @@ public class EcoreReferenceDeserializer extends JsonDeserializer<ReferenceEntry>
             type = jp.nextTextValue();
          }
       }
-
-      return id != null ? new ReferenceEntry.Base(parent, reference, id, type) : null;
+      if (id != null) {
+         return EObjects.isFeatureMapEntry(reference) ? new ReferenceEntry.ForMapEntry(parent, reference, id, type)
+            : new ReferenceEntry.Base(parent, reference, id, type);
+      }
+      return null;
    }
 
 }

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/FeatureMapEntryDeserializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/FeatureMapEntryDeserializer.java
@@ -1,0 +1,215 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.jackson.databind.deser;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static org.eclipse.emfcloud.jackson.databind.EMFContext.getResource;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.ecore.util.FeatureMap;
+import org.eclipse.emf.ecore.util.FeatureMap.Entry;
+import org.eclipse.emf.ecore.util.FeatureMapUtil;
+import org.eclipse.emfcloud.jackson.databind.EMFContext;
+import org.eclipse.emfcloud.jackson.databind.FeatureMapEntryConfig;
+import org.eclipse.emfcloud.jackson.databind.type.EcoreTypeFactory;
+import org.eclipse.emfcloud.jackson.errors.JSONException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
+public class FeatureMapEntryDeserializer extends JsonDeserializer<FeatureMap.Entry> {
+
+   private final FeatureMapEntryConfig config;
+
+   public FeatureMapEntryDeserializer(final FeatureMapEntryConfig config) {
+      this.config = config;
+   }
+
+   /**
+    * Content read during tokens deserialization.
+    */
+   private class DeserializedContent {
+
+      private String featureName;
+      private EStructuralFeature feature;
+      private Object value;
+
+      public String getFeatureName() { return featureName; }
+
+      public void setValue(final Object value) { this.value = value; }
+
+      public Object getValue() { return value; }
+
+      public EStructuralFeature getFeature() { return feature; }
+
+      public void setFeature(final String featureName, final EObject parent) {
+         this.featureName = featureName;
+         feature = doGetFeature(parent, featureName);
+      }
+
+      public boolean isFeatureSet() { return feature != null; }
+
+      /**
+       * Get the feature from the feature name.
+       *
+       * @param parent      the EObject parent
+       * @param featureName the feature name as found in json
+       * @return the feature
+       */
+      private EStructuralFeature doGetFeature(final EObject parent, final String featureName) {
+         if (featureName != null) {
+            Optional<EStructuralFeature> matchingFeature = parent.eClass().getEAllStructuralFeatures().stream().filter(
+               ref -> featureName.equals(config.getPropertyName(ref))).findFirst();
+            // eventually, be lenient if feature name was used instead
+            EStructuralFeature feature = matchingFeature
+               .orElseGet(() -> parent.eClass().getEStructuralFeature(featureName));
+            return feature;
+         }
+         return null;
+      }
+
+   }
+
+   @Override
+   public Entry deserialize(final JsonParser jp, final DeserializationContext ctxt)
+      throws IOException, JsonProcessingException {
+      // get parent now, before children values reading erase it.
+      EObject parent = EMFContext.getParent(ctxt);
+      if (jp.getCurrentToken() != JsonToken.START_OBJECT) {
+         return null;
+      }
+      DeserializedContent content = new DeserializedContent();
+      try (TokenBuffer buffer = new TokenBuffer(jp);) {
+         while (jp.nextToken() != JsonToken.END_OBJECT) {
+            readNextToken(jp, ctxt, parent, content, buffer);
+         }
+         // read value now when it was before the feature
+         if (!buffer.isEmpty() && content.isFeatureSet() && content.getValue() == null) {
+            Object value = readValue(buffer.asParser(), ctxt, parent, content.getFeature());
+            content.setValue(value);
+         }
+      }
+      // create the resulting entry
+      Entry result = createResult(ctxt, parent, content.getFeature(), content.getValue());
+      if (result == null) {
+         handleUnknownProperty(parent, content.getFeatureName(), jp, getResource(ctxt), ctxt);
+      }
+      return result;
+   }
+
+   public void readNextToken(final JsonParser jp, final DeserializationContext ctxt, EObject parent,
+      DeserializedContent content, TokenBuffer buffer) throws IOException {
+      String key = jp.getCurrentName();
+      jp.nextToken();
+
+      boolean readingValue = false;
+      if (config.shouldUseKeyAndValueProperties()) {
+         // look for 'featureName' and 'value' entries
+         if (FeatureMapEntryConfig.KEY_PROPERTY.equals(key)) {
+            content.setFeature(jp.getValueAsString(), parent);
+         } else if (FeatureMapEntryConfig.VALUE_PROPERTY.equals(key)) {
+            readingValue = true;
+         }
+      } else {
+         // key is the feature name
+         content.setFeature(key, parent);
+         readingValue = true;
+      }
+
+      if (readingValue) {
+         if (content.isFeatureSet()) {
+            // proceed with value reading
+            Object value = readValue(jp, ctxt, parent, content.getFeature());
+            content.setValue(value);
+         } else {
+            // we do not have the feature yet, store in buffer so we can read value with the type information
+            buffer.copyCurrentStructure(jp);
+         }
+      }
+   }
+
+   private void handleUnknownProperty(final EObject parent, final String featureName, final JsonParser jp,
+      final Resource resource, final DeserializationContext ctxt)
+      throws IOException {
+      if (resource != null && ctxt.getConfig().hasDeserializationFeatures(FAIL_ON_UNKNOWN_PROPERTIES.getMask())) {
+         resource.getErrors()
+            .add(new JSONException(
+               String.format("Unknown feature '%s' for %s", featureName, EcoreUtil.getURI(parent.eClass())),
+               jp.getCurrentLocation()));
+      }
+   }
+
+   /**
+    * Read and deserialize the value in the map entry.
+    *
+    * @param jp      json parser
+    * @param ctxt    the deserialization context
+    * @param parent  the parent EObject
+    * @param feature the feature holding the value
+    * @return the entry's read value
+    * @throws IOException read exception
+    */
+   public Object readValue(final JsonParser jp, final DeserializationContext ctxt, final EObject parent,
+      final EStructuralFeature feature)
+      throws IOException {
+      Object value;
+      EcoreTypeFactory factory = EMFContext.getTypeFactory(ctxt);
+      JavaType type = factory.typeOf(ctxt, parent.eClass(), feature);
+      if (feature.isMany() && type instanceof CollectionType) {
+         type = type.getContentType();
+      }
+      if (jp.getCurrentToken() == JsonToken.START_OBJECT) {
+         // this may be an EObject definition or a reference...
+         EMFContext.setFeature(ctxt, feature);
+         value = ctxt.readValue(jp, type);
+      } else {
+         value = ctxt.readValue(jp, type);
+      }
+      return value;
+   }
+
+   /**
+    * Create result for deserialization.
+    *
+    * @param ctxt    the deserialization context
+    * @param parent  the parent EObject
+    * @param feature the feature name
+    * @param value   the entry's read value
+    * @return the result map entry
+    */
+   public Entry createResult(final DeserializationContext ctxt, final EObject parent, final EStructuralFeature feature,
+      final Object value) {
+      if (feature != null) {
+         if (value instanceof ReferenceEntry.ForMapEntry) {
+            // make sure entry is resolved later
+            ReferenceEntries entries = EMFContext.getEntries(ctxt);
+            entries.entries().add((ReferenceEntry) value);
+            return ((ReferenceEntry.ForMapEntry) value).createFeatureMapEntry(ctxt);
+         }
+         Entry entry = FeatureMapUtil.createEntry(feature, value);
+         return entry;
+      }
+      return null;
+   }
+
+}

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectFeatureProperty.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectFeatureProperty.java
@@ -31,6 +31,7 @@ import org.eclipse.emfcloud.jackson.databind.type.FeatureKind;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
@@ -102,19 +103,7 @@ public class EObjectFeatureProperty extends EObjectProperty {
                }
             }
 
-            if (feature.isMany()) {
-               if (token != JsonToken.START_ARRAY && !isMap) {
-                  throw new JsonParseException(jp, "Expected START_ARRAY token, got " + token);
-               }
-
-               deserializer.deserialize(jp, ctxt, current.eGet(feature));
-            } else {
-               Object value = deserializer.deserialize(jp, ctxt);
-
-               if (value != null) {
-                  current.eSet(feature, value);
-               }
-            }
+            deserializeValue(jp, current, ctxt, token, isMap);
          }
             break;
          case MANY_REFERENCE:
@@ -122,19 +111,41 @@ public class EObjectFeatureProperty extends EObjectProperty {
             EMFContext.setFeature(ctxt, feature);
             EMFContext.setParent(ctxt, current);
 
-            ReferenceEntries entries = EMFContext.getEntries(ctxt);
-            if (feature.isMany()) {
-               deserializer.deserialize(jp, ctxt, entries.entries());
-            } else {
-               Object value = deserializer.deserialize(jp, ctxt);
-               if (entries != null && value instanceof ReferenceEntry) {
-                  entries.entries().add((ReferenceEntry) value);
-               }
-            }
+            deserializeAsReference(jp, ctxt);
          }
             break;
          default:
             break;
+      }
+   }
+
+   public void deserializeAsReference(final JsonParser jp, final DeserializationContext ctxt)
+      throws IOException, JsonProcessingException {
+      ReferenceEntries entries = EMFContext.getEntries(ctxt);
+      if (feature.isMany()) {
+         deserializer.deserialize(jp, ctxt, entries.entries());
+      } else {
+         Object value = deserializer.deserialize(jp, ctxt);
+         if (entries != null && value instanceof ReferenceEntry) {
+            entries.entries().add((ReferenceEntry) value);
+         }
+      }
+   }
+
+   public void deserializeValue(final JsonParser jp, final EObject current, final DeserializationContext ctxt,
+      final JsonToken token, final boolean isMap) throws JsonParseException, IOException, JsonProcessingException {
+      if (feature.isMany()) {
+         if (token != JsonToken.START_ARRAY && !isMap) {
+            throw new JsonParseException(jp, "Expected START_ARRAY token, got " + token);
+         }
+
+         deserializer.deserialize(jp, ctxt, current.eGet(feature));
+      } else {
+         Object value = deserializer.deserialize(jp, ctxt);
+
+         if (value != null) {
+            current.eSet(feature, value);
+         }
       }
    }
 

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectFeatureProperty.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectFeatureProperty.java
@@ -119,7 +119,7 @@ public class EObjectFeatureProperty extends EObjectProperty {
       }
    }
 
-   public void deserializeAsReference(final JsonParser jp, final DeserializationContext ctxt)
+   protected void deserializeAsReference(final JsonParser jp, final DeserializationContext ctxt)
       throws IOException, JsonProcessingException {
       ReferenceEntries entries = EMFContext.getEntries(ctxt);
       if (feature.isMany()) {
@@ -132,7 +132,7 @@ public class EObjectFeatureProperty extends EObjectProperty {
       }
    }
 
-   public void deserializeValue(final JsonParser jp, final EObject current, final DeserializationContext ctxt,
+   protected void deserializeValue(final JsonParser jp, final EObject current, final DeserializationContext ctxt,
       final JsonToken token, final boolean isMap) throws JsonParseException, IOException, JsonProcessingException {
       if (feature.isMany()) {
          if (token != JsonToken.START_ARRAY && !isMap) {

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectFeatureProperty.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/property/EObjectFeatureProperty.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.FeatureMap;
 import org.eclipse.emfcloud.jackson.databind.EMFContext;
 import org.eclipse.emfcloud.jackson.databind.deser.RawDeserializer;
 import org.eclipse.emfcloud.jackson.databind.deser.ReferenceEntries;
@@ -94,6 +95,11 @@ public class EObjectFeatureProperty extends EObjectProperty {
          case MANY_ATTRIBUTE: {
             if (feature.getEType() instanceof EDataType) {
                EMFContext.setDataType(ctxt, feature.getEType());
+               Class<?> clazz = feature.getEType().getInstanceClass();
+               if (clazz != null && FeatureMap.Entry.class.isAssignableFrom(clazz)) {
+                  // we need the parent to construct the feature map entry with correct feature
+                  EMFContext.setParent(ctxt, current);
+               }
             }
 
             if (feature.isMany()) {

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMFSerializers.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/EMFSerializers.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.impl.EEnumLiteralImpl;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.FeatureMap;
 import org.eclipse.emfcloud.jackson.databind.deser.ReferenceEntry;
 import org.eclipse.emfcloud.jackson.databind.property.EObjectPropertyMap;
 import org.eclipse.emfcloud.jackson.databind.type.EcoreType;
@@ -37,6 +38,7 @@ import com.fasterxml.jackson.databind.type.MapLikeType;
 public class EMFSerializers extends Serializers.Base {
 
    private final EObjectPropertyMap.Builder propertiesBuilder;
+   private final JsonSerializer<FeatureMap.Entry> featureMapEntrySerializer;
    private final JsonSerializer<EObject> referenceSerializer;
    private final JsonSerializer<Resource> resourceSerializer = new ResourceSerializer();
    private final JsonSerializer<?> dataTypeSerializer = new EDataTypeSerializer();
@@ -46,6 +48,7 @@ public class EMFSerializers extends Serializers.Base {
 
    public EMFSerializers(final EMFModule module) {
       this.propertiesBuilder = EObjectPropertyMap.Builder.from(module, module.getFeatures());
+      this.featureMapEntrySerializer = module.getFeatureMapEntrySerializer();
       this.referenceSerializer = module.getReferenceSerializer();
    }
 
@@ -103,6 +106,10 @@ public class EMFSerializers extends Serializers.Base {
 
       if (type.isTypeOrSubTypeOf(EObject.class)) {
          return new EObjectSerializer(propertiesBuilder, referenceSerializer);
+      }
+
+      if (type.isTypeOrSubTypeOf(FeatureMap.Entry.class)) {
+         return featureMapEntrySerializer;
       }
 
       return super.findSerializer(config, type, beanDesc);

--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/FeatureMapEntrySerializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/ser/FeatureMapEntrySerializer.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bonitasoft and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+package org.eclipse.emfcloud.jackson.databind.ser;
+
+import java.io.IOException;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.util.FeatureMap;
+import org.eclipse.emfcloud.jackson.databind.FeatureMapEntryConfig;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * A serializer for {@link org.eclipse.emf.ecore.util.FeatureMap.Entry}.
+ * We need FeatureMap to be displayed as a sequence of entries in order to keep the relative order among different
+ * features.
+ * This serializer takes care of a single entry.
+ *
+ * @author vhemery
+ */
+public class FeatureMapEntrySerializer extends JsonSerializer<FeatureMap.Entry> {
+   private JsonSerializer<EObject> referenceSerializer;
+   private final FeatureMapEntryConfig config;
+
+   public FeatureMapEntrySerializer(final JsonSerializer<EObject> referenceSerializer,
+      final FeatureMapEntryConfig config) {
+      this.referenceSerializer = referenceSerializer;
+      this.config = config;
+   }
+
+   public void setReferenceSerializer(final JsonSerializer<EObject> referenceSerializer) {
+      this.referenceSerializer = referenceSerializer;
+   }
+
+   @Override
+   public Class<FeatureMap.Entry> handledType() {
+      return FeatureMap.Entry.class;
+   }
+
+   @Override
+   public void serialize(final FeatureMap.Entry entry, final JsonGenerator jg, final SerializerProvider serializers)
+      throws IOException {
+      jg.writeStartObject();
+      EStructuralFeature feat = entry.getEStructuralFeature();
+      String featureName = config.getPropertyName(feat);
+      if (shouldUseKeyAndValueProperties()) {
+         // write the feature name with a dedicated property
+         jg.writeStringField(FeatureMapEntryConfig.KEY_PROPERTY, featureName);
+         // write the value
+         if (feat instanceof EReference && !((EReference) feat).isContainment()) {
+            jg.writeFieldName(FeatureMapEntryConfig.VALUE_PROPERTY);
+
+            referenceSerializer.serialize((EObject) entry.getValue(), jg, serializers);
+         } else {
+            jg.writeObjectField(FeatureMapEntryConfig.VALUE_PROPERTY, entry.getValue());
+         }
+      } else {
+         // write value with the feature name as key
+         if (feat instanceof EReference && !((EReference) feat).isContainment()) {
+            jg.writeFieldName(featureName);
+
+            referenceSerializer.serialize((EObject) entry.getValue(), jg, serializers);
+         } else {
+            jg.writeObjectField(featureName, entry.getValue());
+         }
+
+      }
+      jg.writeEndObject();
+   }
+
+   /**
+    * Test whether we should use dedicated {@link FeatureMapEntryConfig#KEY_PROPERTY} and
+    * {@link FeatureMapEntryConfig#VALUE_PROPERTY} properties for feature map
+    * entries.
+    *
+    * @return true when using properties, false otherwise (default)
+    */
+   public boolean shouldUseKeyAndValueProperties() {
+      return config.shouldUseKeyAndValueProperties();
+   }
+
+}

--- a/src/main/java/org/eclipse/emfcloud/jackson/resource/JsonResource.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/resource/JsonResource.java
@@ -19,17 +19,32 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.WeakHashMap;
 
+import org.eclipse.emf.common.util.SegmentSequence;
+import org.eclipse.emf.common.util.SegmentSequence.Builder;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.plugin.EcorePlugin;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.URIConverter;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.ecore.util.FeatureMap;
+import org.eclipse.emf.ecore.util.FeatureMap.Entry;
 import org.eclipse.emfcloud.jackson.databind.EMFContext;
+import org.eclipse.emfcloud.jackson.databind.FeatureMapEntryConfig;
+import org.eclipse.emfcloud.jackson.databind.ser.FeatureMapEntrySerializer;
+import org.eclipse.emfcloud.jackson.utils.EObjects;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.ContextAttributes;
 
@@ -91,13 +106,191 @@ public class JsonResource extends ResourceImpl {
    }
 
    @Override
-   public String getURIFragment(final EObject eObject) {
-      String id = getID(eObject);
+   protected String getIDForEObject(final EObject eObject) {
+      return Optional.ofNullable(getID(eObject)).orElseGet(() -> super.getIDForEObject(eObject));
+   }
 
+   @Override
+   public String getURIFragment(final EObject eObject) {
+      String id = getIDForEObject(eObject);
       if (id != null) {
          return id;
       }
-      return super.getURIFragment(eObject);
+      // else, check if it is a direct root element
+      InternalEObject internalEObject = (InternalEObject) eObject;
+      if (isContainedRoot(internalEObject)) {
+         return "/" + getURIFragmentRootSegment(eObject);
+      }
+      // else, we must build the fragment path
+      SegmentSequence.Builder builder = SegmentSequence.newBuilder("/");
+
+      boolean supportIDRelativeURIFragmentPaths = supportIDRelativeURIFragmentPaths();
+
+      boolean isContained = buildURIFragmentPath(builder, internalEObject, supportIDRelativeURIFragmentPaths);
+
+      if (!isContained) {
+         return "/-1";
+      }
+
+      builder.append("");
+      builder.reverse();
+
+      // Note that we convert it to a segment sequence because the most common use case is that callers of this method
+      // will call URI.appendFragment.
+      // By creating the segment sequence here, we ensure that it's found in the cache.
+      return builder.toSegmentSequence().toString();
+   }
+
+   @Override
+   protected EObject getEObject(final List<String> uriFragmentPath) {
+      int size = uriFragmentPath.size();
+      EObject eObject = getEObjectForURIFragmentRootSegment(size == 0 ? "" : uriFragmentPath.get(0));
+      boolean skipFeatureMapEntryFragment = true;
+      for (int i = 1; i < size && eObject != null; ++i) {
+         // we must check the particular case for Feature Map Entries which are stored differently in json.
+         if (EObjects.isFeatureMapEntry(eObject.eContainingFeature())) {
+            /*
+             * First time, the segment indicates FeatureMapEntrySerializer.VALUE_PROPERTY or the feature.
+             * In either case, we already have the targeted value and do not need to look for another one.
+             * Next times, we have to navigate into the object the classic way.
+             */
+            // find index of the entry containing the value
+            if (skipFeatureMapEntryFragment) {
+               // do nothing
+               skipFeatureMapEntryFragment = false;
+            } else {
+               // navigate into the object
+               eObject = ((InternalEObject) eObject).eObjectForURIFragmentSegment(uriFragmentPath.get(i));
+               skipFeatureMapEntryFragment = true;
+            }
+         } else {
+            eObject = ((InternalEObject) eObject).eObjectForURIFragmentSegment(uriFragmentPath.get(i));
+         }
+
+      }
+
+      return eObject;
+   }
+
+   /**
+    * Builds the URI fragment by building a path.
+    *
+    * @param builder                           the path builder
+    * @param eObject                           the object to build path for
+    * @param supportIDRelativeURIFragmentPaths true when we support path relative to an id
+    * @return true when a build path have been successfully built and the object is correctly contained.
+    */
+   private boolean buildURIFragmentPath(final Builder builder, final InternalEObject eObject,
+      final boolean supportIDRelativeURIFragmentPaths) {
+      InternalEObject container = eObject.eInternalContainer();
+      if (container != null) {
+         // add fragment for element from container
+         if (EObjects.isFeatureMapEntry(eObject.eContainingFeature())) {
+            String generalFeatureName = EObjects.getGroupNameForFeatureMapEntry(eObject.eContainingFeature());
+            EStructuralFeature generalFeature = eObject.eContainer().eClass().getEStructuralFeature(generalFeatureName);
+            // find index of the entry containing the value
+            int index = findEntryIndex(eObject, generalFeature);
+            // construct the fragment
+            StringBuilder fragment = new StringBuilder();
+            fragment.append('@');
+            fragment.append(generalFeatureName);
+            fragment.append('.');
+            fragment.append(index);
+            fragment.append('/');
+            if (useKeyAndValueForFeatureMapEntry()) {
+               fragment.append(FeatureMapEntryConfig.VALUE_PROPERTY);
+            } else {
+               // use specialized feature name
+               fragment.append(eObject.eContainingFeature().getName());
+            }
+            builder.append(fragment.toString());
+         } else {
+            builder.append(container.eURIFragmentSegment(eObject.eContainingFeature(), eObject));
+         }
+
+         if (supportIDRelativeURIFragmentPaths) {
+            String id = getIDForEObject(container);
+            if (id != null) {
+               // end path with id of container
+               builder.append("?" + id);
+               // still look for a root container to make sure it is contained
+               EObject root = EcoreUtil.getRootContainer(eObject);
+               return isContainedRoot((InternalEObject) root);
+            }
+         }
+         // continue building path from container
+         return buildURIFragmentPath(builder, container, supportIDRelativeURIFragmentPaths);
+      }
+      // else, this is the root
+      if (isContainedRoot(eObject)) {
+         builder.append(getURIFragmentRootSegment(eObject));
+         return true;
+      }
+      // else, not contained in a the resource
+      return false;
+   }
+
+   /**
+    * Test whether we should use key and value dedicated properties for feature map entries.
+    *
+    * @return true when using dedicated properties, false when using the feature name (default)
+    */
+   private boolean useKeyAndValueForFeatureMapEntry() {
+      // try and ask the FeatureMap.Entry serializer whether we should use key and value properties
+      try {
+         JsonSerializer<?> ser = this.mapper.getSerializerProviderInstance()
+            .findValueSerializer(FeatureMap.Entry.class);
+         if (ser instanceof FeatureMapEntrySerializer) {
+            return ((FeatureMapEntrySerializer) ser).shouldUseKeyAndValueProperties();
+         }
+      } catch (JsonMappingException e) {
+         EcorePlugin.INSTANCE.log(e);
+      }
+      return false;
+
+   }
+
+   /**
+    * Find the index of the entry containing the value.
+    *
+    * @param eObject           the value EObject
+    * @param generalFeatureMap the general feature with the Map
+    * @return the index or -1 when not found
+    */
+   private int findEntryIndex(final InternalEObject eObject, final EStructuralFeature generalFeatureMap) {
+      // value not found
+      int index = -1;
+      if (generalFeatureMap.isMany()) {
+         Object map = eObject.eContainer().eGet(generalFeatureMap);
+         if (map instanceof FeatureMap) {
+            Iterator<Entry> it = ((FeatureMap) map).iterator();
+            boolean found = false;
+            int itIndex = 0;
+            while (it.hasNext() && !found) {
+               Entry entry = it.next();
+               found = eObject.eContainingFeature().equals(entry.getEStructuralFeature())
+                  && eObject.equals(entry.getValue());
+               if (found) {
+                  index = itIndex;
+               }
+               itIndex++;
+            }
+         }
+      } else {
+         // single value, index is 0
+         index = 0;
+      }
+      return index;
+   }
+
+   /**
+    * Check that the EObject is a root contained in this very resource.
+    *
+    * @param eObject EObject to check
+    * @return true when root correctly contained
+    */
+   private boolean isContainedRoot(final InternalEObject eObject) {
+      return eObject.eDirectResource() == this || unloadingContents != null && unloadingContents.contains(eObject);
    }
 
    public void setID(final EObject eObject, final String id) {

--- a/src/test/java/org/eclipse/emfcloud/jackson/TestSuite.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/TestSuite.java
@@ -23,6 +23,7 @@ import org.eclipse.emfcloud.jackson.tests.ModelTest;
 import org.eclipse.emfcloud.jackson.tests.ModuleTest;
 import org.eclipse.emfcloud.jackson.tests.NoMinimizedTypeTest;
 import org.eclipse.emfcloud.jackson.tests.NoTypeTest;
+import org.eclipse.emfcloud.jackson.tests.NorasCaravanTest;
 import org.eclipse.emfcloud.jackson.tests.PolymorphicTest;
 import org.eclipse.emfcloud.jackson.tests.ReaderTest;
 import org.eclipse.emfcloud.jackson.tests.ReferenceTest;
@@ -70,6 +71,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
    // meta
    ModelTest.class,
+   NorasCaravanTest.class,
 
    // annotations
    JsonPropertyTest.class,

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/FeatureMapTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/FeatureMapTest.java
@@ -10,33 +10,57 @@
  *******************************************************************************/
 package org.eclipse.emfcloud.jackson.tests;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.util.FeatureMap;
+import org.eclipse.emfcloud.jackson.junit.featureMapMixed.AType;
+import org.eclipse.emfcloud.jackson.junit.featureMapMixed.BType;
+import org.eclipse.emfcloud.jackson.junit.featureMapMixed.DocumentRoot;
+import org.eclipse.emfcloud.jackson.junit.featureMapMixed.FeatureMapMixedFactory;
+import org.eclipse.emfcloud.jackson.junit.featureMapMixed.FeatureMapMixedPackage;
 import org.eclipse.emfcloud.jackson.junit.model.ModelFactory;
 import org.eclipse.emfcloud.jackson.junit.model.ModelPackage;
 import org.eclipse.emfcloud.jackson.junit.model.PrimaryObject;
 import org.eclipse.emfcloud.jackson.junit.model.TargetObject;
+import org.eclipse.emfcloud.jackson.module.EMFModule;
 import org.eclipse.emfcloud.jackson.support.StandardFixture;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+@RunWith(Parameterized.class)
 public class FeatureMapTest {
+
+   @Parameterized.Parameters
+   public static Collection<Boolean> booleans() {
+      return List.of(true, false);
+   }
 
    @ClassRule
    public static StandardFixture fixture = new StandardFixture();
-
-   private final ObjectMapper mapper = fixture.mapper();
    private final ResourceSet resourceSet = fixture.getResourceSet();
+   private final ObjectMapper mapper;
+   private final Boolean optionUseFeatureMapKeyAndValueProperties;
+
+   public FeatureMapTest(final Boolean optionUseFeatureMapKeyAndValueProperties) {
+      this.optionUseFeatureMapKeyAndValueProperties = optionUseFeatureMapKeyAndValueProperties;
+      mapper = fixture.mapper(EMFModule.Feature.OPTION_USE_FEATURE_MAP_KEY_AND_VALUE_PROPERTIES,
+         optionUseFeatureMapKeyAndValueProperties);
+   }
 
    @Test
    public void testSaveFeatureMap() throws IOException {
@@ -44,44 +68,72 @@ public class FeatureMapTest {
          .put("eClass", "http://www.emfjson.org/jackson/model#//PrimaryObject")
          .put("name", "junit");
 
-      expected.set("featureMapAttributeType1", mapper.createArrayNode().add("Hello"));
-      expected.set("featureMapAttributeType2", mapper.createArrayNode().add("World"));
+      if (optionUseFeatureMapKeyAndValueProperties) {
+         expected.set("featureMapAttributeCollection", mapper.createArrayNode()
+            .add(mapper.createObjectNode()
+               .put("featureName", "featureMapAttributeType1")
+               .put("value", "Hello"))
+            .add(mapper.createObjectNode()
+               .put("featureName", "featureMapAttributeType2")
+               .put("value", "World"))
+            .add(mapper.createObjectNode()
+               .put("featureName", "featureMapAttributeType1")
+               .put("value", "!")));
+      } else {
+         expected.set("featureMapAttributeCollection", mapper.createArrayNode()
+            .add(mapper.createObjectNode()
+               .put("featureMapAttributeType1", "Hello"))
+            .add(mapper.createObjectNode()
+               .put("valfeatureMapAttributeType2ue", "World"))
+            .add(mapper.createObjectNode()
+               .put("featureMapAttributeType1", "!")));
+      }
 
       PrimaryObject primaryObject = ModelFactory.eINSTANCE.createPrimaryObject();
       primaryObject.setName("junit");
 
-      primaryObject.getFeatureMapAttributeType1().add("Hello");
-      primaryObject.getFeatureMapAttributeType2().add("World");
+      primaryObject.getFeatureMapAttributeCollection()
+         .add(ModelPackage.Literals.PRIMARY_OBJECT__FEATURE_MAP_ATTRIBUTE_TYPE1, "Hello");
+      primaryObject.getFeatureMapAttributeCollection()
+         .add(ModelPackage.Literals.PRIMARY_OBJECT__FEATURE_MAP_ATTRIBUTE_TYPE2, "World");
+      primaryObject.getFeatureMapAttributeCollection()
+         .add(ModelPackage.Literals.PRIMARY_OBJECT__FEATURE_MAP_ATTRIBUTE_TYPE1, "!");
 
-      assertEquals(2, primaryObject.getFeatureMapAttributeCollection().size());
-      assertEquals(1, primaryObject.getFeatureMapAttributeType1().size());
+      assertEquals(3, primaryObject.getFeatureMapAttributeCollection().size());
+      assertEquals(2, primaryObject.getFeatureMapAttributeType1().size());
       assertEquals(1, primaryObject.getFeatureMapAttributeType2().size());
 
       Resource resource = resourceSet.createResource(URI.createURI("test.json"));
       resource.getContents().add(primaryObject);
+
+      System.out.println(mapper.valueToTree(resource));
 
       assertEquals(expected, mapper.valueToTree(resource));
    }
 
    @Test
    public void testLoadFeatureMap() throws IOException {
-      Resource resource = resourceSet.getResource(URI.createURI("src/test/resources/tests/test-load-feature-map.json"),
-         true);
+      Resource resource = resourceSet.getResource(URI.createURI(optionUseFeatureMapKeyAndValueProperties
+         ? "src/test/resources/tests/test-load-feature-map-use-properties.json"
+         : "src/test/resources/tests/test-load-feature-map.json"), true);
 
       assertEquals(1, resource.getContents().size());
       assertTrue(resource.getContents().get(0) instanceof PrimaryObject);
 
       PrimaryObject o = (PrimaryObject) resource.getContents().get(0);
       assertEquals("junit", o.getName());
+      assertArrayEquals(new String[] { "Hello", "World", "!" },
+         o.getFeatureMapAttributeCollection().stream().map(FeatureMap.Entry::getValue).map(Object::toString).toArray());
       assertEquals("Hello", o.getFeatureMapAttributeType1().get(0));
       assertEquals("World", o.getFeatureMapAttributeType2().get(0));
-      assertEquals(2, o.getFeatureMapAttributeCollection().size());
+      assertEquals("!", o.getFeatureMapAttributeType1().get(1));
    }
 
    @Test
    public void testLoadFeatureMapReferences() throws IOException {
-      Resource resource = resourceSet
-         .getResource(URI.createURI("src/test/resources/tests/test-load-feature-map-refs.json"), true);
+      Resource resource = resourceSet.getResource(URI.createURI(optionUseFeatureMapKeyAndValueProperties
+         ? "src/test/resources/tests/test-load-feature-map-refs-use-properties.json"
+         : "src/test/resources/tests/test-load-feature-map-refs.json"), true);
 
       assertEquals(1, resource.getContents().size());
       assertEquals(ModelPackage.Literals.PRIMARY_OBJECT, resource.getContents().get(0).eClass());
@@ -94,18 +146,24 @@ public class FeatureMapTest {
 
       TargetObject t1 = p.getFeatureMapReferenceType2().get(0);
       assertEquals("1", t1.getSingleAttribute());
+      assertEquals(t1, p.getFeatureMapReferenceCollection().get(1).getValue());
 
       TargetObject t2 = p.getFeatureMapReferenceType2().get(1);
       assertEquals("2", t2.getSingleAttribute());
+      assertEquals(t2, p.getFeatureMapReferenceCollection().get(2).getValue());
 
       TargetObject t3 = p.getFeatureMapReferenceType2().get(2);
       assertEquals("3", t3.getSingleAttribute());
+      assertEquals(t1, p.getFeatureMapReferenceCollection().get(3).getValue());
 
       TargetObject t4 = p.getFeatureMapReferenceType2().get(3);
       assertEquals("4", t4.getSingleAttribute());
+      assertEquals(t1, p.getFeatureMapReferenceCollection().get(4).getValue());
 
       assertEquals(t1, p.getFeatureMapReferenceType1().get(0));
+      assertEquals(t1, p.getFeatureMapReferenceCollection().get(0).getValue());
       assertEquals(t2, p.getFeatureMapReferenceType1().get(1));
+      assertEquals(t2, p.getFeatureMapReferenceCollection().get(5).getValue());
    }
 
    @Test
@@ -113,23 +171,53 @@ public class FeatureMapTest {
       ObjectNode expected = mapper.createObjectNode()
          .put("eClass", "http://www.emfjson.org/jackson/model#//PrimaryObject");
 
-      expected.set("featureMapReferenceType1", mapper.createArrayNode()
-         .add(mapper.createObjectNode()
-            .put("eClass", "http://www.emfjson.org/jackson/model#//TargetObject")
-            .put("$ref", "//@featureMapReferenceType2.0"))
-         .add(mapper.createObjectNode()
-            .put("eClass", "http://www.emfjson.org/jackson/model#//TargetObject")
-            .put("$ref", "//@featureMapReferenceType2.1")));
-
-      expected.set("featureMapReferenceType2", mapper.createArrayNode()
-         .add(mapper.createObjectNode()
-            .put("singleAttribute", "1"))
-         .add(mapper.createObjectNode()
-            .put("singleAttribute", "2"))
-         .add(mapper.createObjectNode()
-            .put("singleAttribute", "3"))
-         .add(mapper.createObjectNode()
-            .put("singleAttribute", "4")));
+      if (optionUseFeatureMapKeyAndValueProperties) {
+         expected.set("featureMapReferenceCollection", mapper.createArrayNode()
+            .add(mapper.createObjectNode()
+               .put("featureName", "featureMapReferenceType1")
+               .set("value", mapper.createObjectNode()
+                  .put("$ref", "//@featureMapReferenceCollection.1/value")))
+            .add(mapper.createObjectNode()
+               .put("featureName", "featureMapReferenceType2")
+               .set("value", mapper.createObjectNode()
+                  .put("singleAttribute", "1")))
+            .add(mapper.createObjectNode()
+               .put("featureName", "featureMapReferenceType2")
+               .set("value", mapper.createObjectNode()
+                  .put("singleAttribute", "2")))
+            .add(mapper.createObjectNode()
+               .put("featureName", "featureMapReferenceType2")
+               .set("value", mapper.createObjectNode()
+                  .put("singleAttribute", "3")))
+            .add(mapper.createObjectNode()
+               .put("featureName", "featureMapReferenceType2")
+               .set("value", mapper.createObjectNode()
+                  .put("singleAttribute", "4")))
+            .add(mapper.createObjectNode()
+               .put("featureName", "featureMapReferenceType2")
+               .set("value", mapper.createObjectNode()
+                  .put("$ref", "//@featureMapReferenceCollection.2/value"))));
+      } else {
+         expected.set("featureMapReferenceCollection", mapper.createArrayNode()
+            .add(mapper.createObjectNode()
+               .set("featureMapReferenceType1", mapper.createObjectNode()
+                  .put("$ref", "//@featureMapReferenceCollection.1/featureMapReferenceType2")))
+            .add(mapper.createObjectNode()
+               .set("featureMapReferenceType2", mapper.createObjectNode()
+                  .put("singleAttribute", "1")))
+            .add(mapper.createObjectNode()
+               .set("featureMapReferenceType2", mapper.createObjectNode()
+                  .put("singleAttribute", "2")))
+            .add(mapper.createObjectNode()
+               .set("featureMapReferenceType2", mapper.createObjectNode()
+                  .put("singleAttribute", "3")))
+            .add(mapper.createObjectNode()
+               .set("featureMapReferenceType2", mapper.createObjectNode()
+                  .put("singleAttribute", "4")))
+            .add(mapper.createObjectNode()
+               .set("featureMapReferenceType2", mapper.createObjectNode()
+                  .put("$ref", "//@featureMapReferenceCollection.2/featureMapReferenceType2"))));
+      }
 
       Resource resource = resourceSet.createResource(URI.createURI("tests.json"));
       assertNotNull(resource);
@@ -145,16 +233,85 @@ public class FeatureMapTest {
       t4.setSingleAttribute("4");
 
       p.getFeatureMapReferenceType1().add(t1);
-      p.getFeatureMapReferenceType1().add(t2);
 
       p.getFeatureMapReferenceType2().add(t1);
       p.getFeatureMapReferenceType2().add(t2);
       p.getFeatureMapReferenceType2().add(t3);
       p.getFeatureMapReferenceType2().add(t4);
 
+      p.getFeatureMapReferenceType1().add(t2);
+
       resource.getContents().add(p);
 
       assertEquals(expected, mapper.valueToTree(resource));
+   }
+
+   @Test
+   public void testSaveFeatureMapMixedContent() throws IOException {
+      ObjectNode expected = mapper.createObjectNode()
+         .put("eClass", "http://www.emfjson.org/jackson/featureMapMixed#//DocumentRoot");
+
+      if (optionUseFeatureMapKeyAndValueProperties) {
+         expected.set("mixed", mapper.createArrayNode()
+            .add(mapper.createObjectNode()
+               .put("featureName", "B")
+               .set("value", mapper.createObjectNode()
+                  .put("attributeB", "valueB")))
+            .add(mapper.createObjectNode()
+               .put("featureName", "A")
+               .set("value", mapper.createObjectNode()
+                  .put("attributeA", "valueA"))));
+      } else {
+         expected.set("mixed", mapper.createArrayNode()
+            .add(mapper.createObjectNode()
+               .set("B", mapper.createObjectNode()
+                  .put("attributeB", "valueB")))
+            .add(mapper.createObjectNode()
+               .set("A", mapper.createObjectNode()
+                  .put("attributeA", "valueA"))));
+      }
+
+      DocumentRoot root = FeatureMapMixedFactory.eINSTANCE.createDocumentRoot();
+
+      BType b = FeatureMapMixedFactory.eINSTANCE.createBType();
+      b.setAttributeB("valueB");
+      root.getMixed().add(FeatureMapMixedPackage.Literals.DOCUMENT_ROOT__BELEMENTS, b);
+
+      AType a = FeatureMapMixedFactory.eINSTANCE.createAType();
+      a.setAttributeA("valueA");
+      root.getMixed().add(FeatureMapMixedPackage.Literals.DOCUMENT_ROOT__AELEMENTS, a);
+
+      assertEquals(2, root.getMixed().size());
+      assertNotNull(root.getAElements());
+      assertNotNull(root.getBElements());
+
+      Resource resource = resourceSet.createResource(URI.createURI("test.json"));
+      resource.getContents().add(root);
+
+      System.out.println(mapper.valueToTree(resource));
+
+      assertEquals(expected, mapper.valueToTree(resource));
+   }
+
+   @Test
+   public void testLoadFeatureMapMixedContent() throws IOException {
+      Resource resource = resourceSet.getResource(URI.createURI(optionUseFeatureMapKeyAndValueProperties
+         ? "src/test/resources/tests/test-load-feature-map-mixed-use-properties.json"
+         : "src/test/resources/tests/test-load-feature-map-mixed.json"), true);
+
+      assertEquals(1, resource.getContents().size());
+      assertTrue(resource.getContents().get(0) instanceof DocumentRoot);
+
+      DocumentRoot root = (DocumentRoot) resource.getContents().get(0);
+      Object b = root.getMixed().get(0).getValue();
+      assertTrue(b instanceof BType);
+      assertEquals(root.getBElements(), b);
+      assertEquals("valueB", root.getBElements().getAttributeB());
+
+      Object a = root.getMixed().get(1).getValue();
+      assertTrue(a instanceof AType);
+      assertEquals(root.getAElements(), a);
+      assertEquals("valueA", root.getAElements().getAttributeA());
    }
 
 }

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/NorasCaravanTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/NorasCaravanTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Guillaume Hillairet and others.
+ * Copyright (c) 2024 Bonitasoft and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/NorasCaravanTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/NorasCaravanTest.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Guillaume Hillairet and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ *******************************************************************************/
+package org.eclipse.emfcloud.jackson.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emfcloud.jackson.junit.caravan.CaravanPackage;
+import org.eclipse.emfcloud.jackson.junit.caravan.DocumentRoot;
+import org.eclipse.emfcloud.jackson.junit.caravan.util.CaravanResourceFactoryImpl;
+import org.eclipse.emfcloud.jackson.module.EMFModule;
+import org.eclipse.emfcloud.jackson.resource.JsonResource;
+import org.eclipse.emfcloud.jackson.resource.JsonResourceFactory;
+import org.eclipse.emfcloud.jackson.support.StandardFixture;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * This is a functional test which tests a full model sample for illustrating the usage of feature map entries.
+ */
+@RunWith(Parameterized.class)
+public class NorasCaravanTest {
+
+   @Parameterized.Parameters
+   public static Collection<Boolean> booleans() {
+      return List.of(true, false);
+   }
+
+   @ClassRule
+   public static StandardFixture fixture = new StandardFixture();
+   private final ResourceSet resourceSet = fixture.getResourceSet();
+   private final ObjectMapper mapper;
+   private final Boolean optionUseFeatureMapKeyAndValueProperties;
+
+   public NorasCaravanTest(final Boolean optionUseFeatureMapKeyAndValueProperties) {
+      this.optionUseFeatureMapKeyAndValueProperties = optionUseFeatureMapKeyAndValueProperties;
+      mapper = fixture.mapper(EMFModule.Feature.OPTION_USE_FEATURE_MAP_KEY_AND_VALUE_PROPERTIES,
+         optionUseFeatureMapKeyAndValueProperties);
+      // update the resource factory with correct mapper
+      fixture.getResourceSet().getResourceFactoryRegistry().getExtensionToFactoryMap().put("*",
+         new JsonResourceFactory(mapper));
+      // make sure Caravan package is loaded so that EMF does not try to get it from http
+      CaravanPackage.eINSTANCE.getNsURI();
+   }
+
+   @Test
+   public void testSerializeModel() throws IOException {
+      Resource xmi = getXmiResource();
+      EObject root = xmi.getContents().get(0);
+
+      Resource resource = resourceSet.createResource(URI.createURI("test.json"));
+      ((JsonResource) resource).setObjectMapper(mapper);
+      resource.getContents().add(root);
+
+      JsonNode expected = mapper.readTree(Paths.get(getJsonPath()).toFile());
+
+      assertEquals(expected, mapper.valueToTree(resource));
+   }
+
+   @Test
+   public void testDeserializeModel() throws IOException {
+      Resource resource = resourceSet.getResource(URI.createURI(getJsonPath()), true);
+
+      assertEquals(1, resource.getContents().size());
+
+      Resource xmi = getXmiResource();
+      EObject expected = xmi.getContents().get(0);
+      ((DocumentRoot) expected).eUnset(CaravanPackage.Literals.DOCUMENT_ROOT__XMLNS_PREFIX_MAP);
+
+      assertTrue(EcoreUtil.equals(expected, resource.getContents().get(0)));
+   }
+
+   public Resource getXmiResource() {
+      ResourceSet xmiResourceSet = new ResourceSetImpl();
+      xmiResourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put("*", new CaravanResourceFactoryImpl());
+      xmiResourceSet.getPackageRegistry().put(CaravanPackage.eNS_URI, CaravanPackage.eINSTANCE);
+      Resource xmi = xmiResourceSet.getResource(URI.createURI("src/test/resources/xmi/Nora'sCaravan.xmi"), true);
+      return xmi;
+   }
+
+   /**
+    * Get json resource path depending on the use properties option.
+    *
+    * @return appropriate json file path
+    */
+   public String getJsonPath() {
+      return optionUseFeatureMapKeyAndValueProperties
+         ? "src/test/resources/tests/Nora'sCaravan-use-properties.json"
+         : "src/test/resources/tests/Nora'sCaravan.json";
+   }
+
+}

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/NorasCaravanTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/NorasCaravanTest.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
@@ -31,6 +33,8 @@ import org.eclipse.emfcloud.jackson.module.EMFModule;
 import org.eclipse.emfcloud.jackson.resource.JsonResource;
 import org.eclipse.emfcloud.jackson.resource.JsonResourceFactory;
 import org.eclipse.emfcloud.jackson.support.StandardFixture;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,6 +60,19 @@ public class NorasCaravanTest {
    private final ObjectMapper mapper;
    private final Boolean optionUseFeatureMapKeyAndValueProperties;
 
+   @Before
+   public void setUp() {
+      // make sure Caravan package is loaded so that EMF does not try to get it from http
+      EPackage.Registry.INSTANCE.put(EcorePackage.eNS_URI, EcorePackage.eINSTANCE);
+      EPackage.Registry.INSTANCE.put(CaravanPackage.eNS_URI, CaravanPackage.eINSTANCE);
+   }
+
+   @After
+   public void tearDown() {
+      EPackage.Registry.INSTANCE.clear();
+      Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().clear();
+   }
+
    public NorasCaravanTest(final Boolean optionUseFeatureMapKeyAndValueProperties) {
       this.optionUseFeatureMapKeyAndValueProperties = optionUseFeatureMapKeyAndValueProperties;
       mapper = fixture.mapper(EMFModule.Feature.OPTION_USE_FEATURE_MAP_KEY_AND_VALUE_PROPERTIES,
@@ -63,8 +80,6 @@ public class NorasCaravanTest {
       // update the resource factory with correct mapper
       fixture.getResourceSet().getResourceFactoryRegistry().getExtensionToFactoryMap().put("*",
          new JsonResourceFactory(mapper));
-      // make sure Caravan package is loaded so that EMF does not try to get it from http
-      CaravanPackage.eINSTANCE.getNsURI();
    }
 
    @Test

--- a/src/test/resources/model/caravan.xcore
+++ b/src/test/resources/model/caravan.xcore
@@ -44,13 +44,13 @@ class CaravanType {
 @ExtendedMetaData(name="Person", kind="empty")
 class Person {
     @ExtendedMetaData(kind="attribute", name="firstName")
-    org.eclipse.emf.ecore.xml.^type.String[1] firstName
+    String firstName
 }
 
 @ExtendedMetaData(name="Camel", kind="empty")
 abstract class Camel {
     @ExtendedMetaData(kind="attribute", name="name")
-    org.eclipse.emf.ecore.xml.^type.String[1] name
+    String name
 }
 
 @GenModel(documentation="A camel with two humps.")

--- a/src/test/resources/model/caravan.xcore
+++ b/src/test/resources/model/caravan.xcore
@@ -1,0 +1,64 @@
+@Ecore(nsURI="http://www.emfjson.org/jackson/caravan")
+@GenModel(
+    modelDirectory="emfjson-jackson/src/test/java-gen",
+    updateClasspath="false",
+    bundleManifest="false",
+    rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl",
+    complianceLevel="8.0",
+    documentation="A functional sample metamodel to illustrate the use of FeatureMapEntry with Json."
+)
+package org.eclipse.emfcloud.jackson.junit.caravan
+
+import org.eclipse.emf.ecore.EFeatureMapEntry
+import org.eclipse.emf.ecore.EStringToStringMapEntry
+
+@ExtendedMetaData(name="", kind="mixed")
+class DocumentRoot {
+    @ExtendedMetaData(kind="elementWildcard", name=":mixed")
+    EFeatureMapEntry[] mixed
+    @ExtendedMetaData(kind="attribute", name="xmlns:prefix")
+    contains transient EStringToStringMapEntry[] xMLNSPrefixMap
+    @ExtendedMetaData(kind="attribute", name="xsi:schemaLocation")
+    contains transient EStringToStringMapEntry[] xSISchemaLocation
+    @ExtendedMetaData(kind="element", name="Caravan", namespace="##targetNamespace")
+    contains transient volatile derived CaravanType[0..?] caravan
+    @ExtendedMetaData(kind="element", name="LonePerson", namespace="##targetNamespace")
+    contains transient volatile derived Person[0..?] lonePerson
+}
+
+@ExtendedMetaData(name="Caravan_._type", kind="elementOnly")
+class CaravanType {
+    @ExtendedMetaData(kind="group", name="group:0")
+    EFeatureMapEntry[] group
+    @GenModel(documentation="A human person composing the caravan.")
+    @ExtendedMetaData(kind="element", name="Person", namespace="##targetNamespace", group="#group:0")
+    contains transient volatile derived Person[] person
+    @GenModel(documentation="A dromadery camel composing the caravan.")
+    @ExtendedMetaData(kind="element", name="DromaderyCamel", namespace="##targetNamespace", group="#group:0")
+    contains transient volatile derived DromaderyCamel[] dromaderyCamel
+    @GenModel(documentation="A bactrian camel composing the caravan.")
+    @ExtendedMetaData(kind="element", name="BactrianCamel", namespace="##targetNamespace", group="#group:0")
+    contains transient volatile derived BactrianCamel[] bactrianCamel
+}
+
+@ExtendedMetaData(name="Person", kind="empty")
+class Person {
+    @ExtendedMetaData(kind="attribute", name="firstName")
+    org.eclipse.emf.ecore.xml.^type.String[1] firstName
+}
+
+@ExtendedMetaData(name="Camel", kind="empty")
+abstract class Camel {
+    @ExtendedMetaData(kind="attribute", name="name")
+    org.eclipse.emf.ecore.xml.^type.String[1] name
+}
+
+@GenModel(documentation="A camel with two humps.")
+@ExtendedMetaData(name="BactrianCamel", kind="empty")
+class BactrianCamel extends Camel {
+}
+
+@GenModel(documentation="A camel with only one hump.")
+@ExtendedMetaData(name="DromaderyCamel", kind="empty")
+class DromaderyCamel extends Camel {
+}

--- a/src/test/resources/model/featureMapMixed.xcore
+++ b/src/test/resources/model/featureMapMixed.xcore
@@ -1,0 +1,38 @@
+@Ecore(nsURI="http://www.emfjson.org/jackson/featureMapMixed")
+@GenModel(
+    modelDirectory="emfjson-jackson/src/test/java-gen",
+    updateClasspath="false",
+    bundleManifest="false",
+    rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl",
+    complianceLevel="8.0"
+)
+package org.eclipse.emfcloud.jackson.junit.featureMapMixed
+
+import org.eclipse.emf.ecore.EFeatureMapEntry
+import org.eclipse.emf.ecore.EStringToStringMapEntry
+
+@ExtendedMetaData(name="", kind="mixed")
+class DocumentRoot {
+	@ExtendedMetaData(kind="elementWildcard", name=":mixed")
+	EFeatureMapEntry[] mixed
+    @ExtendedMetaData(kind="attribute", name="xmlns:prefix")
+    contains transient EStringToStringMapEntry[] xMLNSPrefixMap
+    @ExtendedMetaData(kind="attribute", name="xsi:schemaLocation")
+    contains transient EStringToStringMapEntry[] xSISchemaLocation
+
+    @ExtendedMetaData(kind="element", name="A", namespace="##targetNamespace")
+    contains transient volatile derived AType[0..?] aElements
+
+    @ExtendedMetaData(kind="element", name="B", namespace="##targetNamespace")
+    contains transient volatile derived BType[0..?] bElements
+}
+
+@ExtendedMetaData(name="AType", kind="elementOnly")
+class AType {
+    id String attributeA
+}
+
+@ExtendedMetaData(name="BType", kind="elementOnly")
+class BType {
+    id String attributeB
+}

--- a/src/test/resources/tests/Nora'sCaravan-use-properties.json
+++ b/src/test/resources/tests/Nora'sCaravan-use-properties.json
@@ -1,0 +1,36 @@
+{
+  "eClass": "http://www.emfjson.org/jackson/caravan#//DocumentRoot",
+  ":mixed": [
+    {
+      "featureName":"Caravan",
+      "value": {
+        "group:0": [
+         {
+           "featureName":"Person",
+           "value" : {
+             "firstName":"Nora"
+           }
+         },
+         {
+           "featureName":"DromaderyCamel",
+           "value" : {
+             "name":"Grumpy"
+           }
+         },
+         {
+           "featureName":"BactrianCamel",
+           "value" : {
+             "name":"Humpy"
+           }
+         },
+         {
+           "featureName":"DromaderyCamel",
+           "value" : {
+             "name":"Happy"
+           }
+         }
+        ]
+       }
+    }
+  ]
+ }

--- a/src/test/resources/tests/Nora'sCaravan.json
+++ b/src/test/resources/tests/Nora'sCaravan.json
@@ -1,0 +1,31 @@
+{
+  "eClass": "http://www.emfjson.org/jackson/caravan#//DocumentRoot",
+  ":mixed": [
+    {
+      "Caravan": {
+        "group:0": [
+         {
+           "Person": {
+             "firstName":"Nora"
+           }
+         },
+         {
+           "DromaderyCamel": {
+             "name":"Grumpy"
+           }
+         },
+         {
+           "BactrianCamel": {
+             "name":"Humpy"
+           }
+         },
+         {
+           "DromaderyCamel": {
+             "name":"Happy"
+           }
+         }
+        ]
+       }
+    }
+  ]
+ }

--- a/src/test/resources/tests/test-load-feature-map-mixed-use-properties.json
+++ b/src/test/resources/tests/test-load-feature-map-mixed-use-properties.json
@@ -1,0 +1,19 @@
+{
+    "eClass": "http://www.emfjson.org/jackson/featureMapMixed#DocumentRoot",
+    "mixed": [
+        {
+            "featureName": "B",
+            "value": {
+                "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//BType",
+                "attributeB": "valueB"
+            }
+        },
+        {
+            "featureName": "A",
+            "value": {
+                "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//PurchaseOrderType",
+                "attributeA": "valueA"
+            }
+        }
+    ]
+  }

--- a/src/test/resources/tests/test-load-feature-map-mixed-use-properties.json
+++ b/src/test/resources/tests/test-load-feature-map-mixed-use-properties.json
@@ -1,19 +1,19 @@
 {
-    "eClass": "http://www.emfjson.org/jackson/featureMapMixed#DocumentRoot",
-    "mixed": [
-        {
-            "featureName": "B",
-            "value": {
-                "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//BType",
-                "attributeB": "valueB"
-            }
-        },
-        {
-            "featureName": "A",
-            "value": {
-                "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//PurchaseOrderType",
-                "attributeA": "valueA"
-            }
-        }
-    ]
-  }
+  "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//DocumentRoot",
+  ":mixed": [
+    {
+      "featureName": "B",
+      "value": {
+        "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//BType",
+        "attributeB": "valueB"
+      }
+    },
+    {
+      "featureName": "A",
+      "value": {
+        "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//AType",
+        "attributeA": "valueA"
+      }
+    }
+  ]
+}

--- a/src/test/resources/tests/test-load-feature-map-mixed.json
+++ b/src/test/resources/tests/test-load-feature-map-mixed.json
@@ -1,0 +1,17 @@
+{
+    "eClass": "http://www.emfjson.org/jackson/featureMapMixed#DocumentRoot",
+    "mixed": [
+        {
+            "B": {
+                "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//BType",
+                "attributeB": "valueB"
+            }
+        },
+        {
+            "A": {
+                "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//PurchaseOrderType",
+                "attributeA": "valueA"
+            }
+        }
+    ]
+  }

--- a/src/test/resources/tests/test-load-feature-map-mixed.json
+++ b/src/test/resources/tests/test-load-feature-map-mixed.json
@@ -1,17 +1,17 @@
 {
-    "eClass": "http://www.emfjson.org/jackson/featureMapMixed#DocumentRoot",
-    "mixed": [
-        {
-            "B": {
-                "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//BType",
-                "attributeB": "valueB"
-            }
-        },
-        {
-            "A": {
-                "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//PurchaseOrderType",
-                "attributeA": "valueA"
-            }
-        }
-    ]
-  }
+  "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//DocumentRoot",
+  ":mixed": [
+    {
+      "B": {
+        "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//BType",
+        "attributeB": "valueB"
+      }
+    },
+    {
+      "A": {
+        "eClass": "http://www.emfjson.org/jackson/featureMapMixed#//AType",
+        "attributeA": "valueA"
+      }
+    }
+  ]
+}

--- a/src/test/resources/tests/test-load-feature-map-refs-use-properties.json
+++ b/src/test/resources/tests/test-load-feature-map-refs-use-properties.json
@@ -4,8 +4,8 @@
     {
       "featureName": "featureMapReferenceType1",
       "value": {
-        "$ref": "//@featureMapReferenceCollection.1/value",
-        "eClass": "http://www.emfjson.org/jackson/model#//TargetObject"
+        "eClass": "http://www.emfjson.org/jackson/model#//TargetObject",
+        "$ref": "//@featureMapReferenceCollection.1/value"
       }
     },
     {
@@ -39,8 +39,8 @@
     {
       "featureName": "featureMapReferenceType1",
       "value": {
-        "$ref": "//@featureMapReferenceCollection.2/value",
-        "eClass": "http://www.emfjson.org/jackson/model#//TargetObject"
+        "eClass": "http://www.emfjson.org/jackson/model#//TargetObject",
+        "$ref": "//@featureMapReferenceCollection.2/value"
       }
     }
   ]

--- a/src/test/resources/tests/test-load-feature-map-refs-use-properties.json
+++ b/src/test/resources/tests/test-load-feature-map-refs-use-properties.json
@@ -2,37 +2,43 @@
   "eClass": "http://www.emfjson.org/jackson/model#//PrimaryObject",
   "featureMapReferenceCollection": [
     {
-      "featureMapReferenceType1": {
+      "featureName": "featureMapReferenceType1",
+      "value": {
         "$ref": "//@featureMapReferenceCollection.1/value",
         "eClass": "http://www.emfjson.org/jackson/model#//TargetObject"
       }
     },
     {
-      "featureMapReferenceType2": {
+      "featureName": "featureMapReferenceType2",
+      "value": {
         "eClass": "http://www.emfjson.org/jackson/model#//TargetObject",
         "singleAttribute": "1"
       }
     },
     {
-      "featureMapReferenceType2": {
+      "featureName": "featureMapReferenceType2",
+      "value": {
         "eClass": "http://www.emfjson.org/jackson/model#//TargetObject",
         "singleAttribute": "2"
       }
     },
     {
-      "featureMapReferenceType2": {
+      "featureName": "featureMapReferenceType2",
+      "value": {
         "eClass": "http://www.emfjson.org/jackson/model#//TargetObject",
         "singleAttribute": "3"
       }
     },
     {
-      "featureMapReferenceType2": {
+      "featureName": "featureMapReferenceType2",
+      "value": {
         "eClass": "http://www.emfjson.org/jackson/model#//TargetObject",
         "singleAttribute": "4"
       }
     },
     {
-      "featureMapReferenceType1": {
+      "featureName": "featureMapReferenceType1",
+      "value": {
         "$ref": "//@featureMapReferenceCollection.2/value",
         "eClass": "http://www.emfjson.org/jackson/model#//TargetObject"
       }

--- a/src/test/resources/tests/test-load-feature-map-refs.json
+++ b/src/test/resources/tests/test-load-feature-map-refs.json
@@ -3,8 +3,8 @@
   "featureMapReferenceCollection": [
     {
       "featureMapReferenceType1": {
-        "$ref": "//@featureMapReferenceCollection.1/value",
-        "eClass": "http://www.emfjson.org/jackson/model#//TargetObject"
+        "eClass": "http://www.emfjson.org/jackson/model#//TargetObject",
+        "$ref": "//@featureMapReferenceCollection.1/featureMapReferenceType2"
       }
     },
     {
@@ -33,8 +33,8 @@
     },
     {
       "featureMapReferenceType1": {
-        "$ref": "//@featureMapReferenceCollection.2/value",
-        "eClass": "http://www.emfjson.org/jackson/model#//TargetObject"
+        "eClass": "http://www.emfjson.org/jackson/model#//TargetObject",
+        "$ref": "//@featureMapReferenceCollection.2/featureMapReferenceType2"
       }
     }
   ]

--- a/src/test/resources/tests/test-load-feature-map-use-properties.json
+++ b/src/test/resources/tests/test-load-feature-map-use-properties.json
@@ -1,0 +1,18 @@
+{
+  "eClass": "http://www.emfjson.org/jackson/model#//PrimaryObject",
+  "name": "junit",
+  "featureMapAttributeCollection": [
+    {
+      "featureName": "featureMapAttributeType1",
+      "value": "Hello"
+    },
+    {
+      "featureName": "featureMapAttributeType2",
+      "value": "World"
+    },
+    {
+      "featureName": "featureMapAttributeType1",
+      "value": "!"
+    },
+  ]
+}

--- a/src/test/resources/tests/test-load-feature-map-use-properties.json
+++ b/src/test/resources/tests/test-load-feature-map-use-properties.json
@@ -13,6 +13,6 @@
     {
       "featureName": "featureMapAttributeType1",
       "value": "!"
-    },
+    }
   ]
 }

--- a/src/test/resources/tests/test-load-feature-map.json
+++ b/src/test/resources/tests/test-load-feature-map.json
@@ -10,6 +10,6 @@
     },
     {
       "featureMapAttributeType1": "!"
-    },
+    }
   ]
 }

--- a/src/test/resources/tests/test-load-feature-map.json
+++ b/src/test/resources/tests/test-load-feature-map.json
@@ -1,6 +1,15 @@
 {
   "eClass": "http://www.emfjson.org/jackson/model#//PrimaryObject",
   "name": "junit",
-  "featureMapAttributeType1": [ "Hello" ],
-  "featureMapAttributeType2": [ "World" ]
+  "featureMapAttributeCollection": [
+    {
+      "featureMapAttributeType1": "Hello"
+    },
+    {
+      "featureMapAttributeType2": "World"
+    },
+    {
+      "featureMapAttributeType1": "!"
+    },
+  ]
 }

--- a/src/test/resources/xmi/Nora'sCaravan.xmi
+++ b/src/test/resources/xmi/Nora'sCaravan.xmi
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<caravan:Caravan xmlns:caravan="http://www.emfjson.org/jackson/caravan" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <caravan:Person firstName="Nora"/>
+  <caravan:DromaderyCamel name="Grumpy"/>
+  <caravan:BactrianCamel name="Humpy"/>
+  <caravan:DromaderyCamel name="Happy"/>
+</caravan:Caravan>


### PR DESCRIPTION
Provide a mapping for FeatureMapEntries with JSON.
Dedicated Serializer and Deserializer handle the mapping and deserializer has a specific reference entries resolution.

The "Nora'sCaravan" model is a fully functional model which illustrates the problematic and could not be mapped with the old approach.

**Note this changes the fragment paths in JsonResource**:
Since the JSON and XMI paths to elements can not correspond, URI fragment is different in JSON and XMI. This concerns only paths in feature maps, no impact outside of feature maps.
(We can not have the same path since JSON does not allow duplicates nor specific properties ordering. So either we have different paths or we are not JSON compatible.)
This specific fragment path is handled correctly by the JsonResource implementation.

This mapping comes with two flavors, configurable with the EMFModule.Feature.OPTION_USE_FEATURE_MAP_KEY_AND_VALUE_PROPERTIES option:
- using the feature name as the entry's key (lighter default option).
- using "featureName" for name of the feature and "value" for the feature value composing the entry.
Both options are illustrated in the example and tests.

Closes https://github.com/eclipse-emfcloud/emfjson-jackson/issues/8