### PR TITLE
fix(deser): EMap deserialization fixed context (#76)

### DIFF
--- a/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/EMapDeserializer.java
+++ b/src/main/java/org/eclipse/emfcloud/jackson/databind/deser/EMapDeserializer.java
@@ -12,6 +12,7 @@ package org.eclipse.emfcloud.jackson.databind.deser;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.EMap;
@@ -40,19 +41,15 @@ public class EMapDeserializer extends JsonDeserializer<EList<Map.Entry<?, ?>>> {
    @SuppressWarnings({ "unchecked", "checkstyle:cyclomaticComplexity", "rawtypes" })
    public EList<Map.Entry<?, ?>> deserialize(final JsonParser jp, final DeserializationContext ctxt,
       final EList<Map.Entry<?, ?>> intoValue) throws IOException {
-      EReference reference = EMFContext.getReference(ctxt);
-
-      if (reference != null) {
-         EClass referenceType = reference.getEReferenceType();
-         EStructuralFeature valueFeature = referenceType.getEStructuralFeature("value");
-
-         if (valueFeature != null) {
-            EMFContext.setFeature(ctxt, valueFeature);
-         }
-      }
+      final EObject parent = EMFContext.getParent(ctxt);
+      final EReference mapReference = EMFContext.getReference(ctxt);
+      final Optional<EStructuralFeature> valueFeature = extractValueFeature(ctxt);
 
       if (jp.getCurrentToken() == JsonToken.START_OBJECT) {
          while (jp.nextToken() != JsonToken.END_OBJECT) {
+            // At each loop context, restore the context, which may have gotten deeper exploring children
+            restoreContextForMapValue(ctxt, parent, valueFeature);
+
             String key = jp.getCurrentName();
             jp.nextToken();
 
@@ -67,13 +64,41 @@ public class EMapDeserializer extends JsonDeserializer<EList<Map.Entry<?, ?>>> {
             // but store entries in a DynamicEList instead.
             if (intoValue instanceof EMap) {
                ((EMap) intoValue).put(key, value);
-            } else if (reference != null) {
-               intoValue.add((Map.Entry<?, ?>) EObjects.createEntry(key, value, reference.getEReferenceType()));
+            } else if (mapReference != null) {
+               intoValue.add((Map.Entry<?, ?>) EObjects.createEntry(key, value, mapReference.getEReferenceType()));
             }
          }
       }
 
       return intoValue;
+   }
+
+   /**
+    * Restore the deserialization context in a state adequate to read the map value.
+    *
+    * @param ctxt         deserialization context to update
+    * @param parent       the parent holding the map feature
+    * @param valueFeature the feature holding the value of a Map Entry
+    */
+   private void restoreContextForMapValue(final DeserializationContext ctxt, final EObject parent,
+      final Optional<EStructuralFeature> valueFeature) {
+      EMFContext.setParent(ctxt, parent);
+      valueFeature.ifPresent(f -> EMFContext.setFeature(ctxt, f));
+   }
+
+   /**
+    * Extract the value feature from the deserialization context, at the time of EMap feature reading.
+    *
+    * @param ctxt deserialization context
+    * @return the feature holding the value of a Map Entry
+    */
+   private Optional<EStructuralFeature> extractValueFeature(final DeserializationContext ctxt) {
+      EReference mapReference = EMFContext.getReference(ctxt);
+      return Optional.ofNullable(mapReference).flatMap(ref -> {
+         EClass referenceType = ref.getEReferenceType();
+         EStructuralFeature valueFeature = referenceType.getEStructuralFeature("value");
+         return Optional.ofNullable(valueFeature);
+      });
    }
 
 }

--- a/src/test/java/org/eclipse/emfcloud/jackson/tests/MapTest.java
+++ b/src/test/java/org/eclipse/emfcloud/jackson/tests/MapTest.java
@@ -193,6 +193,61 @@ public class MapTest {
    }
 
    @Test
+   public void testSaveMapWithContainmentInValue() throws IOException {
+      JsonNode expected = mapper.readTree(
+         Paths.get("src/test/resources/tests/test-map-with-containment-in-value.json").toFile());
+
+      Resource resource = resourceSet.createResource(URI.createURI("test"));
+
+      ETypes types = ModelFactory.eINSTANCE.createETypes();
+
+      PrimaryObject p1 = ModelFactory.eINSTANCE.createPrimaryObject();
+      p1.setName("p1");
+      TargetObject c1 = ModelFactory.eINSTANCE.createTargetObject();
+      c1.setSingleAttribute("c1");
+      p1.getMultipleContainmentReferenceNoProxies().add(c1);
+
+      PrimaryObject p2 = ModelFactory.eINSTANCE.createPrimaryObject();
+      p2.setName("p2");
+      TargetObject c2 = ModelFactory.eINSTANCE.createTargetObject();
+      c2.setSingleAttribute("c2");
+      p2.getMultipleContainmentReferenceNoProxies().add(c2);
+
+      types.getStringMapValuesWithContainmentInValue().put("Hello", p1);
+      types.getStringMapValuesWithContainmentInValue().put("World", p2);
+
+      resource.getContents().add(types);
+
+      JsonNode actual = mapper.valueToTree(resource);
+      assertThat(actual).isEqualTo(expected);
+   }
+
+   @Test
+   public void testLoadMapWithContainmentInValue() {
+      Resource resource = resourceSet.getResource(
+         URI.createURI("src/test/resources/tests/test-map-with-containment-in-value.json"),
+         true);
+
+      assertThat(resource.getContents()).hasSize(1);
+      assertThat(resource.getContents().get(0)).isInstanceOf(ETypes.class);
+
+      ETypes types = (ETypes) resource.getContents().get(0);
+
+      EMap<String, PrimaryObject> mapValues = types.getStringMapValuesWithContainmentInValue();
+      assertThat(mapValues).hasSize(2);
+
+      PrimaryObject p1 = mapValues.get("Hello");
+      PrimaryObject p2 = mapValues.get("World");
+
+      assertThat(p1.getName()).isEqualTo("p1");
+      assertThat(p1.getMultipleContainmentReferenceNoProxies().size()).isEqualTo(1);
+      assertThat(p1.getMultipleContainmentReferenceNoProxies().get(0).getSingleAttribute()).isEqualTo("c1");
+      assertThat(p2.getName()).isEqualTo("p2");
+      assertThat(p2.getMultipleContainmentReferenceNoProxies().size()).isEqualTo(1);
+      assertThat(p2.getMultipleContainmentReferenceNoProxies().get(0).getSingleAttribute()).isEqualTo("c2");
+   }
+
+   @Test
    public void testSaveMapWithDataTypeKey() {
       JsonNode expected = mapper.createObjectNode()
          .put("eClass", "http://www.emfjson.org/jackson/model#//ETypes")

--- a/src/test/resources/model/model.xcore
+++ b/src/test/resources/model/model.xcore
@@ -60,6 +60,7 @@ class ETypes {
 	contains TMap[*] values
 	contains TMapRef[*] valuesWithRef
 	contains StringMap[*] stringMapValues
+	contains StringMapWithContainment[*] stringMapValuesWithContainmentInValue
 	contains DataTypeMap[*] dataTypeMapValues
 	unique URI[] uris
 }
@@ -67,6 +68,11 @@ class ETypes {
 class StringMap wraps Map.Entry {
 	String key
 	contains Value value
+}
+
+class StringMapWithContainment wraps Map.Entry {
+	String key
+	contains PrimaryObject value
 }
 
 class TMap wraps Map.Entry {

--- a/src/test/resources/tests/test-map-with-containment-in-value.json
+++ b/src/test/resources/tests/test-map-with-containment-in-value.json
@@ -1,0 +1,21 @@
+{
+  "eClass": "http://www.emfjson.org/jackson/model#//ETypes",
+  "stringMapValuesWithContainmentInValue": {
+    "Hello": {
+      "name": "p1",
+      "multipleContainmentReferenceNoProxies": [
+        {
+          "singleAttribute": "c1"
+        }
+	  ]
+    },
+    "World": {
+      "name": "p2",
+      "multipleContainmentReferenceNoProxies":	  [
+        {
+          "singleAttribute": "c2"
+        }
+	  ]
+    }
+  }
+}


### PR DESCRIPTION
Reset the context to original state while deserializing EMap entries.
The context may have been updated while reading the value's children...

closes #76